### PR TITLE
Examples table

### DIFF
--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -12,7 +12,8 @@ module Trisagion.Examples.Table (
     initLines,
 
     -- * Error types.
-    TableError (..),
+    SignatureError (..),
+    LineError (..),
 
     -- * Parsers.
     parseHeader,
@@ -23,6 +24,8 @@ module Trisagion.Examples.Table (
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
+import Data.Functor.Identity (Identity (..))
+import Data.Void (absurd)
 
 -- Libraries.
 import Control.Monad.State (MonadState (..))
@@ -33,10 +36,9 @@ import qualified Data.Text as Text (lines, pack, empty)
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
-import Trisagion.Get (Get, eval)
+import Trisagion.Get (Get, eval, replace)
 import Trisagion.Getters.Combinators (onParseError)
 import Trisagion.Getters.Streamable (one, matchElem, InputError, MatchError)
-import Data.Void (Void, absurd)
 
 {- | A type alias for @t'Stream' ['Text']@. -}
 type Lines = Stream [Text]
@@ -47,23 +49,23 @@ initLines :: Text -> Lines
 initLines text = initialize (Text.lines text)
 
 
-{- | The @TableError@ error type. -}
-data TableError e
-    = HeaderError   -- ^ Error raised on incorrect table signature.
-    | LineError e   -- ^ Error raised on a line parsing failure.
-    deriving stock (Eq, Show, Functor)
+{- | The @HeaderError@ error type. -}
+data SignatureError = SignatureError
+    deriving stock (Eq, Show)
+
+{- | The @LineError@ error type. -}
+newtype LineError e = LineError e
+    deriving stock (Eq, Show)
+    deriving Functor via Identity
 
 
 {- | Parser for the header of a .tbl table. -}
-parseHeader :: Get Lines (ParseError Lines (TableError e)) Text
-parseHeader = onParseError HeaderError (matchElem (Text.pack "tbl-v1.0"))
+parseHeader :: Get Lines (ParseError Lines SignatureError) Text
+parseHeader = onParseError SignatureError (matchElem (Text.pack "tbl-v1.0"))
 
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
-parseComment = matchElem '#' *> first absurd remainder
-    where
-        remainder :: Get Text Void Text
-        remainder = get <* put Text.empty
+parseComment = matchElem '#' *> first absurd (replace Text.empty)
 
 {- | Parse one line with a 'Text' parser.
 
@@ -73,7 +75,7 @@ note(s):
 -}
 parseLineWith 
     :: Get Text e a
-    -> Get Lines (ParseError Lines (Either InputError (TableError e))) a
+    -> Get Lines (ParseError Lines (Either InputError (LineError e))) a
 parseLineWith p = do
     s    <- get
     text <- first (fmap Left) one

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -13,32 +13,33 @@ module Trisagion.Examples.Table (
 
     -- * Error types.
     SignatureError (..),
-    LineError (..),
+
+    -- * Generic parsers.
+    parseLineWith,
 
     -- * Parsers.
     parseHeader,
     parseComment,
-    parseLineWith,
+    parseFields,
 ) where
 
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
-import Data.Functor.Identity (Identity (..))
 import Data.Void (absurd)
 
 -- Libraries.
-import Control.Monad.State (MonadState (..))
-import Control.Monad.Except (MonadError (..))
+import Control.Monad.State (gets)
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, empty)
+import qualified Data.Text as Text (lines, pack, empty, strip, words)
 
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
-import Trisagion.Types.ParseError (ParseError, makeParseError)
-import Trisagion.Get (Get, eval, replace)
-import Trisagion.Getters.Combinators (onParseError)
-import Trisagion.Getters.Streamable (one, matchElem, InputError, MatchError)
+import Trisagion.Types.ParseError (ParseError)
+import Trisagion.Get (Get, eval)
+import Trisagion.Getters.Combinators (onParseError, replace, validate)
+import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
+
 
 {- | A type alias for @t'Stream' ['Text']@. -}
 type Lines = Stream [Text]
@@ -49,15 +50,21 @@ initLines :: Text -> Lines
 initLines text = initialize (Text.lines text)
 
 
-{- | The @HeaderError@ error type. -}
+{- | The @SignatureError@ error type. -}
 data SignatureError = SignatureError
     deriving stock (Eq, Show)
 
-{- | The @LineError@ error type. -}
-newtype LineError e = LineError e
-    deriving stock (Eq, Show)
-    deriving Functor via Identity
 
+{- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
+
+note(s):
+
+    * any unconsumed input by the 'Text' parser is discarded.
+-}
+parseLineWith
+    :: Get Text e a
+    -> Get Lines (ParseError Lines (Either InputError e)) a
+parseLineWith p = validate (eval p) (Text.strip <$> one)
 
 {- | Parser for the header of a .tbl table. -}
 parseHeader :: Get Lines (ParseError Lines SignatureError) Text
@@ -65,21 +72,8 @@ parseHeader = onParseError SignatureError (matchElem (Text.pack "tbl-v1.0"))
 
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
-parseComment = matchElem '#' *> first absurd (replace Text.empty)
+parseComment = matchElem '#' *> first absurd (replace (const Text.empty))
 
-{- | Parse one line with a 'Text' parser.
-
-note(s):
-
-    * any unconsumed input by the 'Text' parser is discarded.
--}
-parseLineWith 
-    :: Get Text e a
-    -> Get Lines (ParseError Lines (Either InputError (LineError e))) a
-parseLineWith p = do
-    s    <- get
-    text <- first (fmap Left) one
-    either
-        (throwError . makeParseError s . Right . LineError)
-        pure
-        (eval p text)
+{- | Parse one line as a possibly empty list of field, or column, names. -}
+parseFields :: Get Lines (ParseError Lines InputError) [Text]
+parseFields = first (fmap (either id absurd)) $ parseLineWith (gets Text.words)

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -139,9 +139,7 @@ parseRows fields = go
                                 Just ps -> (ps :) <$> go
 
 {- | Parser for an entire .tbl table. -}
-parseTable
-    :: (NonEmpty (Text, Text) -> a)
-    -> Get Lines (ParseError Lines TableError) [a]
-parseTable processRow = do
+parseTable :: Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
+parseTable = do
         _  <- onParseError HeaderError parseHeader
-        onParseError FieldsError parseFields >>= fmap (fmap processRow) . parseRows
+        onParseError FieldsError parseFields >>= parseRows

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -1,0 +1,40 @@
+{- |
+Module: Trisagion.Examples.Table
+
+Parser for the .tbl tabular format.
+-}
+
+module Trisagion.Examples.Table (
+    -- * Streams.
+    Lines,
+
+    -- ** Constructors.
+    initLines,
+
+    -- * Error types.
+    TableError,
+) where
+
+-- Imports.
+-- Libraries.
+import Data.Text (Text)
+import qualified Data.Text as Text (lines)
+
+-- Package.
+import Trisagion.Streams.Streamable (Stream, initialize)
+
+
+{- | A type alias for @t'Stream' ['Text']@. -}
+type Lines = Stream [Text]
+
+
+{- | Construct a t'Lines' streamable from @'Text.lines' text@. -}
+initLines :: Text -> Lines
+initLines text = initialize (Text.lines text)
+
+
+{- | The @TableError@ error type. -}
+data TableError
+    = HeaderError
+    | FieldsError
+    deriving stock (Eq, Show)

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -17,25 +17,28 @@ module Trisagion.Examples.Table (
     -- * Auxiliary parsers.
     parseHeader,
     parseComment,
+    parseFieldOrComment,
+    parseRow,
     parseFields,
 ) where
 
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
-import Data.Void (absurd)
+import Data.Void (Void, absurd)
 
 -- Libraries.
 import Control.Monad.State (gets)
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, empty, strip, words)
+import qualified Data.Text as Text (lines, pack, empty, strip, words, null)
 
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (replace, validate)
+import Trisagion.Getters.Combinators (replace, validate,option)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
+import Trisagion.Getters.Char (notSpaces, spaces)
 
 
 {- | A type alias for @t'Stream' ['Text']@. -}
@@ -65,6 +68,24 @@ parseHeader = matchElem (Text.pack "tbl-v1.0")
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
 parseComment = matchElem '#' *> first absurd (replace (const Text.empty))
+
+{- | Parser for a either a comment or a field in a .tbl row. -}
+parseFieldOrComment :: Get Text Void (Either Text Text)
+parseFieldOrComment = option parseComment >>= maybe (Right <$> notSpaces) (pure . Left)
+
+{- | Parser for a .tbl table row. -}
+parseRow :: Get Lines (ParseError Lines InputError) [Text]
+parseRow = first (fmap (either id absurd)) $ parseLineWith go
+    where
+        go :: Get Text Void [Text]
+        go = do
+            r <- spaces *> parseFieldOrComment
+            case r of
+                Left _     -> pure []
+                Right field ->
+                    if Text.null field
+                        then pure []
+                        else (field :) <$> go
 
 {- | Parse one line as a possibly empty list of field, or column, names. -}
 parseFields :: Get Lines (ParseError Lines InputError) [Text]

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -16,24 +16,27 @@ module Trisagion.Examples.Table (
 
     -- * Parsers.
     parseHeader,
-    parseFields,
+    parseComment,
+    parseLineWith,
 ) where
 
 -- Imports.
 -- Base.
-import Data.List.NonEmpty (NonEmpty, nonEmpty)
+import Data.Bifunctor (Bifunctor (..))
 
 -- Libraries.
+import Control.Monad.State (MonadState (..))
+import Control.Monad.Except (MonadError (..))
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, words, strip, null)
+import qualified Data.Text as Text (lines, pack, empty)
 
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
-import Trisagion.Types.ParseError (ParseError)
-import Trisagion.Get (Get)
-import Trisagion.Getters.Combinators (onParseError, validate)
-import Trisagion.Getters.Streamable (InputError, ValidationError (..), one, matchElem)
-
+import Trisagion.Types.ParseError (ParseError, makeParseError)
+import Trisagion.Get (Get, eval)
+import Trisagion.Getters.Combinators (onParseError)
+import Trisagion.Getters.Streamable (one, matchElem, InputError, MatchError)
+import Data.Void (Void, absurd)
 
 {- | A type alias for @t'Stream' ['Text']@. -}
 type Lines = Stream [Text]
@@ -45,28 +48,36 @@ initLines text = initialize (Text.lines text)
 
 
 {- | The @TableError@ error type. -}
-data TableError
-    = HeaderError
-    | FieldsError
-    deriving stock (Eq, Show)
+data TableError e
+    = HeaderError   -- ^ Error raised on incorrect table signature.
+    | LineError e   -- ^ Error raised on a line parsing failure.
+    deriving stock (Eq, Show, Functor)
 
 
 {- | Parser for the header of a .tbl table. -}
-parseHeader :: Get Lines (ParseError Lines TableError ) Text
+parseHeader :: Get Lines (ParseError Lines (TableError e)) Text
 parseHeader = onParseError HeaderError (matchElem (Text.pack "tbl-v1.0"))
 
-{- | Get the next non-empty line, stripped of whitespace on both sides. -}
-nextNonEmpty :: Get Lines (ParseError Lines InputError) Text
-nextNonEmpty = do
-    xs <- Text.strip <$> one
-    if Text.null xs
-        then nextNonEmpty
-        else pure xs
+{- | Parser for a comment in a .tbl row. -}
+parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
+parseComment = matchElem '#' *> first absurd remainder
+    where
+        remainder :: Get Text Void Text
+        remainder = get <* put Text.empty
 
-{- | Parse the next non-empty line into a 'NonEmpty' of words. -}
-parseLine :: Get Lines (ParseError Lines (Either InputError ValidationError)) (NonEmpty Text)
-parseLine = validate (maybe (Left ValidationError) Right . nonEmpty) (Text.words <$> nextNonEmpty)
+{- | Parse one line with a 'Text' parser.
 
-{- | Parser for the fields line of a .tbl table. -}
-parseFields :: Get Lines (ParseError Lines TableError) (NonEmpty Text)
-parseFields = onParseError FieldsError parseLine
+note(s):
+
+    * any unconsumed input by the 'Text' parser is discarded.
+-}
+parseLineWith 
+    :: Get Text e a
+    -> Get Lines (ParseError Lines (Either InputError (TableError e))) a
+parseLineWith p = do
+    s    <- get
+    text <- first (fmap Left) one
+    either
+        (throwError . makeParseError s . Right . LineError)
+        pure
+        (eval p text)

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -41,15 +41,16 @@ import Data.Void (Void, absurd)
 import Control.Monad.Except (MonadError(..))
 import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, empty, strip, null)
+import qualified Data.Text as Text (lines, pack, strip, null)
 
 -- Package.
 import Trisagion.Lib.NonEmpty (zipExact)
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (replace, validate,option, onParseError)
+import Trisagion.Getters.Combinators (validate, option, onParseError)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
+import Trisagion.Getters.Splittable (remainder)
 import Trisagion.Getters.Char (notSpaces, spaces)
 
 
@@ -95,7 +96,7 @@ parseHeader = matchElem (Text.pack "tbl-v1.0")
 
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
-parseComment = matchElem '#' *> first absurd (replace (const Text.empty))
+parseComment = matchElem '#' *> first absurd remainder
 
 {- | Parser for a either a comment or a field in a .tbl row. -}
 parseFieldOrComment :: Get Text Void (Either Text Text)

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -12,7 +12,7 @@ module Trisagion.Examples.Table (
     initLines,
 
     -- * Error types.
-    TableError,
+    TableError (..),
 
     -- * Parsers.
     parseHeader,

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -12,12 +12,17 @@ module Trisagion.Examples.Table (
     initLines,
 
     -- * Error types.
+    EmptyLineError (..),
+    MismatchError (..),
     TableError (..),
 
     -- * Generic parsers.
     parseLineWith,
 
-    -- * Auxiliary parsers.
+    -- * Parsers.
+    parseTable,
+
+    -- ** Auxiliary parsers.
     parseHeader,
     parseComment,
     parseFieldOrComment,
@@ -33,19 +38,19 @@ import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Void (Void, absurd)
 
 -- Libraries.
+import Control.Monad.Except (MonadError(..))
+import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
 import qualified Data.Text as Text (lines, pack, empty, strip, null)
 
 -- Package.
+import Trisagion.Lib.NonEmpty (zipExact)
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (replace, validate,option)
+import Trisagion.Getters.Combinators (replace, validate,option, onParseError)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
 import Trisagion.Getters.Char (notSpaces, spaces)
-import Trisagion.Lib.NonEmpty (zipExact)
-import Control.Monad.Except (MonadError(..))
-import Control.Monad.State (MonadState(..))
 
 
 {- | A type alias for @t'Stream' ['Text']@. -}
@@ -57,11 +62,19 @@ initLines :: Text -> Lines
 initLines text = initialize (Text.lines text)
 
 
+{- | The @EmptyLineError@ error type, raised on an empty line. -}
+data EmptyLineError = EmptyLineError
+    deriving stock (Eq, Show)
+
+{- | The @MismatchError@ error type, raised when the number of values and field names are not equal. -}
+data MismatchError = MismatchError
+    deriving stock (Eq, Show)
+
 {- | The @TableError@ error type. -}
 data TableError
-    = SignatureError
+    = HeaderError
     | FieldsError
-    | MatchError
+    | RowError
     deriving stock (Eq, Show)
 
 
@@ -79,10 +92,6 @@ parseLineWith p = validate (eval p) (Text.strip <$> one)
 {- | Parser for the header of a .tbl table. -}
 parseHeader :: Get Lines (ParseError Lines (Either InputError (MatchError Text))) Text
 parseHeader = matchElem (Text.pack "tbl-v1.0")
-
-{- | Parse one line as a 'NonEmpty' of field names. -}
-parseFields :: Get Lines (ParseError Lines (Either InputError TableError)) (NonEmpty Text)
-parseFields = validate (maybe (Left FieldsError) Right . nonEmpty) parseRow
 
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
@@ -106,6 +115,10 @@ parseRow = first (fmap (either id absurd)) $ parseLineWith go
                         then pure []
                         else (field :) <$> go
 
+{- | Parse one line as a 'NonEmpty' of field names. -}
+parseFields :: Get Lines (ParseError Lines (Either InputError EmptyLineError)) (NonEmpty Text)
+parseFields = validate (maybe (Left EmptyLineError) Right . nonEmpty) parseRow
+
 {- | Parser for a non-empty list of .tbl table rows. -}
 parseRows :: NonEmpty Text -> Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
 parseRows fields = go
@@ -118,8 +131,16 @@ parseRows fields = go
                 Just ts ->
                     case nonEmpty ts of
                         -- Case of empty line.
-                        Nothing -> parseRows fields
+                        Nothing -> go
                         Just fs ->
                             case zipExact fields fs of
-                                Nothing -> throwError $ makeParseError s MatchError
-                                Just ps -> (ps :) <$> parseRows fields
+                                Nothing -> throwError $ makeParseError s RowError
+                                Just ps -> (ps :) <$> go
+
+{- | Parser for an entire .tbl table. -}
+parseTable
+    :: (NonEmpty (Text, Text) -> a)
+    -> Get Lines (ParseError Lines TableError) [a]
+parseTable processRow = do
+        _  <- onParseError HeaderError parseHeader
+        onParseError FieldsError parseFields >>= fmap (fmap processRow) . parseRows

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -11,6 +11,9 @@ module Trisagion.Examples.Table (
     -- ** Constructors.
     initLines,
 
+    -- * Error types.
+    TableError (..),
+
     -- * Generic parsers.
     parseLineWith,
 
@@ -20,25 +23,29 @@ module Trisagion.Examples.Table (
     parseFieldOrComment,
     parseRow,
     parseFields,
+    parseRows,
 ) where
 
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Void (Void, absurd)
 
 -- Libraries.
-import Control.Monad.State (gets)
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, empty, strip, words, null)
+import qualified Data.Text as Text (lines, pack, empty, strip, null)
 
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
-import Trisagion.Types.ParseError (ParseError)
+import Trisagion.Types.ParseError (ParseError, makeParseError)
 import Trisagion.Get (Get, eval)
 import Trisagion.Getters.Combinators (replace, validate,option)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
 import Trisagion.Getters.Char (notSpaces, spaces)
+import Trisagion.Lib.NonEmpty (zipExact)
+import Control.Monad.Except (MonadError(..))
+import Control.Monad.State (MonadState(..))
 
 
 {- | A type alias for @t'Stream' ['Text']@. -}
@@ -48,6 +55,14 @@ type Lines = Stream [Text]
 {- | Construct a t'Lines' streamable from @'Text.lines' text@. -}
 initLines :: Text -> Lines
 initLines text = initialize (Text.lines text)
+
+
+{- | The @TableError@ error type. -}
+data TableError
+    = SignatureError
+    | FieldsError
+    | MatchError
+    deriving stock (Eq, Show)
 
 
 {- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
@@ -65,6 +80,10 @@ parseLineWith p = validate (eval p) (Text.strip <$> one)
 parseHeader :: Get Lines (ParseError Lines (Either InputError (MatchError Text))) Text
 parseHeader = matchElem (Text.pack "tbl-v1.0")
 
+{- | Parse one line as a 'NonEmpty' of field names. -}
+parseFields :: Get Lines (ParseError Lines (Either InputError TableError)) (NonEmpty Text)
+parseFields = validate (maybe (Left FieldsError) Right . nonEmpty) parseRow
+
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
 parseComment = matchElem '#' *> first absurd (replace (const Text.empty))
@@ -81,12 +100,26 @@ parseRow = first (fmap (either id absurd)) $ parseLineWith go
         go = do
             r <- spaces *> parseFieldOrComment
             case r of
-                Left _     -> pure []
+                Left _      -> pure []
                 Right field ->
                     if Text.null field
                         then pure []
                         else (field :) <$> go
 
-{- | Parse one line as a possibly empty list of field, or column, names. -}
-parseFields :: Get Lines (ParseError Lines InputError) [Text]
-parseFields = first (fmap (either id absurd)) $ parseLineWith (gets Text.words)
+{- | Parser for a non-empty list of .tbl table rows. -}
+parseRows :: NonEmpty Text -> Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
+parseRows fields = go
+    where
+        go = do
+            s <- get
+            r <- first absurd $ option parseRow
+            case r of
+                Nothing -> pure []
+                Just ts ->
+                    case nonEmpty ts of
+                        -- Case of empty line.
+                        Nothing -> parseRows fields
+                        Just fs ->
+                            case zipExact fields fs of
+                                Nothing -> throwError $ makeParseError s MatchError
+                                Just ps -> (ps :) <$> parseRows fields

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -11,13 +11,10 @@ module Trisagion.Examples.Table (
     -- ** Constructors.
     initLines,
 
-    -- * Error types.
-    SignatureError (..),
-
     -- * Generic parsers.
     parseLineWith,
 
-    -- * Parsers.
+    -- * Auxiliary parsers.
     parseHeader,
     parseComment,
     parseFields,
@@ -37,7 +34,7 @@ import qualified Data.Text as Text (lines, pack, empty, strip, words)
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (onParseError, replace, validate)
+import Trisagion.Getters.Combinators (replace, validate)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
 
 
@@ -48,11 +45,6 @@ type Lines = Stream [Text]
 {- | Construct a t'Lines' streamable from @'Text.lines' text@. -}
 initLines :: Text -> Lines
 initLines text = initialize (Text.lines text)
-
-
-{- | The @SignatureError@ error type. -}
-data SignatureError = SignatureError
-    deriving stock (Eq, Show)
 
 
 {- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
@@ -67,8 +59,8 @@ parseLineWith
 parseLineWith p = validate (eval p) (Text.strip <$> one)
 
 {- | Parser for the header of a .tbl table. -}
-parseHeader :: Get Lines (ParseError Lines SignatureError) Text
-parseHeader = onParseError SignatureError (matchElem (Text.pack "tbl-v1.0"))
+parseHeader :: Get Lines (ParseError Lines (Either InputError (MatchError Text))) Text
+parseHeader = matchElem (Text.pack "tbl-v1.0")
 
 {- | Parser for a comment in a .tbl row. -}
 parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -13,15 +13,26 @@ module Trisagion.Examples.Table (
 
     -- * Error types.
     TableError,
+
+    -- * Parsers.
+    parseHeader,
+    parseFields,
 ) where
 
 -- Imports.
+-- Base.
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
+
 -- Libraries.
 import Data.Text (Text)
-import qualified Data.Text as Text (lines)
+import qualified Data.Text as Text (lines, pack, words, strip, null)
 
 -- Package.
 import Trisagion.Streams.Streamable (Stream, initialize)
+import Trisagion.Types.ParseError (ParseError)
+import Trisagion.Get (Get)
+import Trisagion.Getters.Combinators (onParseError, validate)
+import Trisagion.Getters.Streamable (InputError, ValidationError (..), one, matchElem)
 
 
 {- | A type alias for @t'Stream' ['Text']@. -}
@@ -38,3 +49,24 @@ data TableError
     = HeaderError
     | FieldsError
     deriving stock (Eq, Show)
+
+
+{- | Parser for the header of a .tbl table. -}
+parseHeader :: Get Lines (ParseError Lines TableError ) Text
+parseHeader = onParseError HeaderError (matchElem (Text.pack "tbl-v1.0"))
+
+{- | Get the next non-empty line, stripped of whitespace on both sides. -}
+nextNonEmpty :: Get Lines (ParseError Lines InputError) Text
+nextNonEmpty = do
+    xs <- Text.strip <$> one
+    if Text.null xs
+        then nextNonEmpty
+        else pure xs
+
+{- | Parse the next non-empty line into a 'NonEmpty' of words. -}
+parseLine :: Get Lines (ParseError Lines (Either InputError ValidationError)) (NonEmpty Text)
+parseLine = validate (maybe (Left ValidationError) Right . nonEmpty) (Text.words <$> nextNonEmpty)
+
+{- | Parser for the fields line of a .tbl table. -}
+parseFields :: Get Lines (ParseError Lines TableError) (NonEmpty Text)
+parseFields = onParseError FieldsError parseLine

--- a/src/Trisagion/Get.hs
+++ b/src/Trisagion/Get.hs
@@ -14,6 +14,9 @@ module Trisagion.Get (
     eval,
     exec,
 
+    -- * State parsers.
+    replace,
+
     -- * Error parsers.
     handleError,
 
@@ -181,6 +184,10 @@ eval p = withResult Left (\ _ x -> Right x) . run p
 exec :: Get s e a -> s -> Either e s
 exec p = withResult Left (\ s _ -> Right s) . run p
 
+
+{- | Parser returning the remainder of the state and replacing it with something else. -}
+replace :: s -> Get s Void s
+replace s = get <* put s
 
 {- | Type-changing version of 'catchError'. -}
 handleError

--- a/src/Trisagion/Get.hs
+++ b/src/Trisagion/Get.hs
@@ -14,9 +14,6 @@ module Trisagion.Get (
     eval,
     exec,
 
-    -- * State parsers.
-    replace,
-
     -- * Error parsers.
     handleError,
 
@@ -184,10 +181,6 @@ eval p = withResult Left (\ _ x -> Right x) . run p
 exec :: Get s e a -> s -> Either e s
 exec p = withResult Left (\ s _ -> Right s) . run p
 
-
-{- | Parser returning the remainder of the state and replacing it with something else. -}
-replace :: s -> Get s Void s
-replace s = get <* put s
 
 {- | Type-changing version of 'catchError'. -}
 handleError

--- a/src/Trisagion/Getters/Char.hs
+++ b/src/Trisagion/Getters/Char.hs
@@ -14,6 +14,7 @@ module Trisagion.Getters.Char (
 
     -- * Whitespace parsers.
     spaces,
+    notSpaces,
 
     -- * Numeric parsers.
     sign,
@@ -25,7 +26,7 @@ module Trisagion.Getters.Char (
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor(..))
-import Data.Char (isDigit, ord)
+import Data.Char (isDigit, ord, isSpace)
 import Data.Foldable (foldl')
 import Data.Maybe (fromMaybe)
 import Data.Void (Void, absurd)
@@ -60,14 +61,13 @@ cr
     => Get s (ParseError s (Either InputError (MatchError Char))) Char
 cr = matchElem '\r'
 
-{- | Parser for a, possibly empty, prefix of whitespace.
-
-note(s):
-
-    * Includes tabs but not newline characters.
--}
+{- | Parser for a possibly null prefix of whitespace. -}
 spaces :: (Splittable s, Element s ~ Char) => Get s Void (PrefixOf s)
-spaces = takeWith (\c -> c == '\t' || c == ' ')
+spaces = takeWith isSpace
+
+{- | Parser for a possibly null prefix of non-whitespace characters. -}
+notSpaces :: (Splittable s, Element s ~ Char) => Get s Void (PrefixOf s)
+notSpaces = takeWith (not . isSpace)
 
 {- | Parser for the number sign. -}
 sign

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -10,9 +10,6 @@ module Trisagion.Getters.Combinators (
     lookAhead,
     option,
 
-    -- * State parsers.
-    replace,
-
     -- * Handling t'ParseError'.
     validate,
     onParseErrorWith,
@@ -58,7 +55,7 @@ import Data.Void (Void, absurd)
 
 -- Libraries.
 import Control.Monad.Except (MonadError (..))
-import Control.Monad.State (MonadState (..), gets)
+import Control.Monad.State (MonadState (..))
 
 -- Package.
 import Trisagion.Types.ParseError (ParseError (..), initial, makeParseError)
@@ -83,10 +80,6 @@ The difference with @'Control.Applicative.optional'@ is the more precise type si
 -}
 option :: Get s e a -> Get s Void (Maybe a)
 option p = either (const Nothing) Just <$> observe p
-
-{- | Parser returning the remainder of the state and replacing it with something else. -}
-replace :: (s -> s) -> Get s Void s
-replace f = get <* (gets f >>= put) 
 
 {- | Run parser and return the result, validating it. -}
 validate

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -10,6 +10,9 @@ module Trisagion.Getters.Combinators (
     lookAhead,
     option,
 
+    -- * State parsers.
+    replace,
+
     -- * Handling t'ParseError'.
     validate,
     onParseErrorWith,
@@ -55,7 +58,7 @@ import Data.Void (Void, absurd)
 
 -- Libraries.
 import Control.Monad.Except (MonadError (..))
-import Control.Monad.State (MonadState (..))
+import Control.Monad.State (MonadState (..), gets)
 
 -- Package.
 import Trisagion.Types.ParseError (ParseError (..), initial, makeParseError)
@@ -80,6 +83,10 @@ The difference with @'Control.Applicative.optional'@ is the more precise type si
 -}
 option :: Get s e a -> Get s Void (Maybe a)
 option p = either (const Nothing) Just <$> observe p
+
+{- | Parser returning the remainder of the state and replacing it with something else. -}
+replace :: (s -> s) -> Get s Void s
+replace f = get <* (gets f >>= put) 
 
 {- | Run parser and return the result, validating it. -}
 validate

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -89,9 +89,10 @@ validate
 validate v p = do
     s <- get
     r <- first (fmap Left) p
-    case v r of
-        Left e -> throwError $ makeParseError s (Right e)
-        Right x -> pure x
+    either
+        (throwError . makeParseError s . Right)
+        pure
+        (v r)
 
 {- | Add error context to a parser. -}
 onParseErrorWith
@@ -101,7 +102,9 @@ onParseErrorWith
     -> Get s (ParseError s d) a     -- ^ Parser to try.
     -> Get s (ParseError s e) a
 onParseErrorWith s err p = do
-    handleError p (\ e -> throwError $ ParseError (Just e) s err)
+    handleError
+        p
+        (\ e -> throwError $ ParseError (Just e) s err)
 
 {- | Specialized version of 'onParseErrorWith' capturing the current parser state. -}
 onParseError

--- a/src/Trisagion/Getters/Splittable.hs
+++ b/src/Trisagion/Getters/Splittable.hs
@@ -9,6 +9,7 @@ module Trisagion.Getters.Splittable (
     isolateWith,
 
     -- * Parsers with @'Splittable' s@ constraint.
+    remainder,
     takePrefix,
     dropPrefix,
     takeExact,
@@ -53,6 +54,12 @@ isolateWith h p = do
             case eval p prefix of
                 Left e -> throwError $ makeParseError prefix (Right e)
                 Right x -> put suffix $> x
+
+{- | Get the rest of the input stream. -}
+remainder :: Splittable s => Get s Void (PrefixOf s)
+remainder = do
+    (prefix, suffix) <- gets getRemainder
+    put suffix $> prefix
 
 {- | Get a fixed size prefix from the stream.
 

--- a/src/Trisagion/Streams/Streamable.hs
+++ b/src/Trisagion/Streams/Streamable.hs
@@ -12,7 +12,8 @@ module Trisagion.Streams.Streamable (
     initialize,
 
     -- ** Getters.
-    offset,
+    getOffset,
+    getStream,
 ) where
 
 -- Imports.
@@ -71,5 +72,9 @@ initialize :: s -> Stream s
 initialize = Stream 0
 
 {- | Return the current offset of the t'Stream'. -}
-offset :: Stream s -> Word
-offset (Stream off _) = off
+getOffset :: Stream s -> Word
+getOffset (Stream off _) = off
+
+{- | Return the underlying stream. -}
+getStream :: Stream s -> s
+getStream (Stream _ s) = s

--- a/src/Trisagion/Typeclasses/Splittable.hs
+++ b/src/Trisagion/Typeclasses/Splittable.hs
@@ -18,12 +18,12 @@ import Data.Word (Word8)
 import Data.MonoTraversable (Element)
 import Data.Sequence (Seq)
 import Data.Vector (Vector)
-import qualified Data.ByteString as Bytes (ByteString, span, splitAt)
-import qualified Data.ByteString.Lazy as LazyBytes (ByteString, span, splitAt)
-import qualified Data.Text as Text (Text, span, splitAt)
-import qualified Data.Text.Lazy as LazyText (Text, span, splitAt)
-import qualified Data.Sequence as Sequence (spanl, splitAt)
-import qualified Data.Vector as Vector (span, splitAt)
+import qualified Data.ByteString as Bytes (ByteString, span, splitAt, empty)
+import qualified Data.ByteString.Lazy as LazyBytes (ByteString, span, splitAt, empty)
+import qualified Data.Text as Text (Text, span, splitAt, empty)
+import qualified Data.Text.Lazy as LazyText (Text, span, splitAt, empty)
+import qualified Data.Sequence as Seq (spanl, splitAt, empty)
+import qualified Data.Vector as Vector (span, splitAt, empty)
 
 -- Package.
 import Trisagion.Typeclasses.Streamable (Streamable (..))
@@ -44,6 +44,10 @@ class Streamable s => Splittable s where
     @prefix@ is the longest prefix whose elements satisfy @p@ and @suffix@ is the remainder. -}
     getWith :: (Element s -> Bool) -> s -> (PrefixOf s, s)
 
+    {- | Get the remainder of the stream as a prefix. -}
+    getRemainder :: s -> (PrefixOf s, s)
+    getRemainder = getWith (const True)
+
 
 -- Instances.
 instance Splittable Bytes.ByteString where
@@ -55,6 +59,9 @@ instance Splittable Bytes.ByteString where
     getWith :: (Word8 -> Bool) -> Bytes.ByteString -> (Bytes.ByteString, Bytes.ByteString)
     getWith = Bytes.span
 
+    getRemainder :: Bytes.ByteString -> (Bytes.ByteString, Bytes.ByteString)
+    getRemainder xs = (xs, Bytes.empty)
+
 instance Splittable LazyBytes.ByteString where
     type PrefixOf LazyBytes.ByteString = LazyBytes.ByteString
 
@@ -63,6 +70,9 @@ instance Splittable LazyBytes.ByteString where
 
     getWith :: (Word8 -> Bool) -> LazyBytes.ByteString -> (LazyBytes.ByteString, LazyBytes.ByteString)
     getWith = LazyBytes.span
+
+    getRemainder :: LazyBytes.ByteString -> (LazyBytes.ByteString, LazyBytes.ByteString)
+    getRemainder xs = (xs, LazyBytes.empty)
 
 instance Splittable Text.Text where
     type PrefixOf Text.Text = Text.Text
@@ -73,6 +83,9 @@ instance Splittable Text.Text where
     getWith :: (Char -> Bool) -> Text.Text -> (Text.Text, Text.Text)
     getWith = Text.span
 
+    getRemainder :: Text.Text -> (Text.Text, Text.Text)
+    getRemainder xs = (xs, Text.empty)
+
 instance Splittable LazyText.Text where
     type PrefixOf LazyText.Text = LazyText.Text
 
@@ -81,6 +94,9 @@ instance Splittable LazyText.Text where
 
     getWith :: (Char -> Bool) -> LazyText.Text -> (LazyText.Text, LazyText.Text)
     getWith = LazyText.span
+
+    getRemainder :: LazyText.Text -> (LazyText.Text, LazyText.Text)
+    getRemainder xs = (xs, LazyText.empty)
 
 instance Splittable [a] where
     type PrefixOf [a] = [a]
@@ -91,14 +107,20 @@ instance Splittable [a] where
     getWith :: (a -> Bool) -> [a] -> ([a], [a])
     getWith = span
 
+    getRemainder :: [a] -> ([a], [a])
+    getRemainder xs = (xs, [])
+
 instance Splittable (Seq a) where
     type PrefixOf (Seq a) = Seq a
 
     getAt :: Word -> Seq a -> (Seq a, Seq a)
-    getAt n = Sequence.splitAt $ fromIntegral n
+    getAt n = Seq.splitAt $ fromIntegral n
 
     getWith :: (a -> Bool) -> Seq a -> (Seq a, Seq a)
-    getWith = Sequence.spanl
+    getWith = Seq.spanl
+
+    getRemainder :: Seq a -> (Seq a, Seq a)
+    getRemainder xs = (xs, Seq.empty)
 
 instance Splittable (Vector a) where
     type PrefixOf (Vector a) = Vector a
@@ -108,3 +130,6 @@ instance Splittable (Vector a) where
 
     getWith :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
     getWith = Vector.span
+
+    getRemainder :: Vector a -> (Vector a, Vector a)
+    getRemainder xs = (xs, Vector.empty)

--- a/src/Trisagion/Types/ParseError.hs
+++ b/src/Trisagion/Types/ParseError.hs
@@ -12,9 +12,9 @@ module Trisagion.Types.ParseError (
     makeParseError,
 
     -- ** Prisms.
-    state,
-    tag,
-    backtrace,
+    getState,
+    getTag,
+    getBacktrace,
 
     -- ** Elimination functions.
     withParseError,
@@ -78,18 +78,18 @@ makeParseError = ParseError (Nothing :: Maybe (ParseError s Void))
 
 
 {- | Getter for the error state component. -}
-state :: ParseError s e -> Maybe s
-state = withParseError Nothing (\ _ s _ -> Just s)
+getState :: ParseError s e -> Maybe s
+getState = withParseError Nothing (\ _ s _ -> Just s)
 
 {- | Getter for the error tag. -}
-tag :: ParseError s e -> Maybe e
-tag = withParseError Nothing (\ _ _ e -> Just e)
+getTag :: ParseError s e -> Maybe e
+getTag = withParseError Nothing (\ _ _ e -> Just e)
 
 {- | Getter for the backtrace of an error as an elimination function. -}
-backtrace :: (forall d . s -> d -> a) -> ParseError s e -> [a]
-backtrace f  = go
+getBacktrace :: (forall d . s -> d -> a) -> ParseError s e -> [a]
+getBacktrace f  = go
     where
-        go (ParseError r s e) = f s e : maybe [] (backtrace f) r
+        go (ParseError r s e) = f s e : maybe [] (getBacktrace f) r
         go Fail               = []
 
 

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -15,7 +15,9 @@ import Trisagion.Examples.Table
 
 -- Libraries.
 import qualified Data.Text as Text (pack, empty)
-import Trisagion.Getters.Streamable (InputError(..))
+
+-- Package.
+import Trisagion.Getters.Streamable (InputError (..), MatchError (..) )
 
 
 -- Main module test driver.
@@ -40,21 +42,21 @@ spec_parseHeader = describe "parseHeader" $ do
         testTableError
             parseHeader
             "some arbitrary text\nsome more text"
-            SignatureError
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
             (0, "some arbitrary text")
 
     it "Failure on leading whitespace" $ do
         testTableError
             parseHeader
             "   tbl-v1.0\nsome more text"
-            SignatureError
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
             (0, "   tbl-v1.0")
 
     it "Failure on wrong casing" $ do
         testTableError
             parseHeader
             "TBL-v1.0\nsome more text"
-            SignatureError
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
             (0, "TBL-v1.0")
 
 spec_parseComment :: Spec

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -15,6 +15,7 @@ import Trisagion.Examples.Table
 
 -- Libraries.
 import qualified Data.Text as Text (pack, empty)
+import Trisagion.Getters.Streamable (InputError(..))
 
 
 -- Main module test driver.
@@ -22,6 +23,7 @@ spec :: Spec
 spec = describe "Trisagion.Examples.Table tests" $ do
     spec_parseHeader
     spec_parseComment
+    spec_parseFields
 
 
 -- Tests.
@@ -63,3 +65,46 @@ spec_parseComment = describe "parseComment" $ do
             (Text.pack "#some arbitrary text")
             (Text.pack "some arbitrary text")
             Text.empty
+
+spec_parseFields :: Spec
+spec_parseFields = describe "parseFields" $ do
+    it "Success case" $ do
+        testTableSuccess
+            parseFields
+            "some arbitrary text"
+            (Text.pack <$> ["some", "arbitrary", "text"])
+            (1, "")
+
+    it "Success with leading whitespace" $ do
+        testTableSuccess
+            parseFields
+            " \r\v\t\f   some arbitrary text"
+            (Text.pack <$> ["some", "arbitrary", "text"])
+            (1, "")
+
+    it "Success with empty line" $ do
+        testTableSuccess
+            parseFields
+            "    "
+            []
+            (1, "")
+
+    it "Success with comment character" $ do
+        testTableSuccess
+            parseFields
+            "some #arbitrary text"
+            (Text.pack <$> ["some", "#arbitrary", "text"])
+            (1, "")
+
+        testTableSuccess
+            parseFields
+            "some arbi##trary text"
+            (Text.pack <$> ["some", "arbi##trary", "text"])
+            (1, "")
+
+    it "Failure on no input" $ do
+        testTableError
+            parseFields
+            ""
+            (InputError 1)
+            (0, "")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -14,13 +14,15 @@ import Tests.Helpers
 import Trisagion.Examples.Table
 
 -- Libraries.
-import qualified Data.Text as Text (pack)
+import qualified Data.Text as Text (pack, empty)
+import Data.Void (Void)
 
 
 -- Main module test driver.
 spec :: Spec
 spec = describe "Trisagion.Examples.Table tests" $ do
     spec_parseHeader
+    spec_parseComment
 
 
 -- Tests.
@@ -33,16 +35,32 @@ spec_parseHeader = describe "parseHeader" $ do
             (Text.pack "tbl-v1.0")
             (1, "some more text")
 
+    it "Failure on mismatch" $ do
+        testTableError
+            parseHeader
+            "some arbitrary text\nsome more text"
+            (HeaderError :: TableError Void)
+            (0, "some arbitrary text")
+
     it "Failure on leading whitespace" $ do
         testTableError
             parseHeader
             "   tbl-v1.0\nsome more text"
-            HeaderError
+            (HeaderError :: TableError Void)
             (0, "   tbl-v1.0")
 
     it "Failure on wrong casing" $ do
         testTableError
             parseHeader
             "TBL-v1.0\nsome more text"
-            HeaderError
+            (HeaderError :: TableError Void)
             (0, "TBL-v1.0")
+
+spec_parseComment :: Spec
+spec_parseComment = describe "parseComment" $ do
+    it "Success case" $ do
+        testSuccess
+            parseComment
+            (Text.pack "#some arbitrary text")
+            (Text.pack "some arbitrary text")
+            Text.empty

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -1,0 +1,48 @@
+module Tests.Examples.TableSpec (
+    -- * Tests.
+    spec,
+) where
+
+-- Imports.
+-- Testing library.
+import Test.Hspec
+
+-- Testing helpers.
+import Tests.Helpers
+
+-- Module to test.
+import Trisagion.Examples.Table
+
+-- Libraries.
+import qualified Data.Text as Text (pack)
+
+
+-- Main module test driver.
+spec :: Spec
+spec = describe "Trisagion.Examples.Table tests" $ do
+    spec_parseHeader
+
+
+-- Tests.
+spec_parseHeader :: Spec
+spec_parseHeader = describe "parseHeader" $ do
+    it "Success case" $ do
+        testTableSuccess
+            parseHeader
+            "tbl-v1.0\nsome more text"
+            (Text.pack "tbl-v1.0")
+            (1, "some more text")
+
+    it "Failure on leading whitespace" $ do
+        testTableError
+            parseHeader
+            "   tbl-v1.0\nsome more text"
+            HeaderError
+            (0, "   tbl-v1.0")
+
+    it "Failure on wrong casing" $ do
+        testTableError
+            parseHeader
+            "TBL-v1.0\nsome more text"
+            HeaderError
+            (0, "TBL-v1.0")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -25,6 +25,8 @@ spec :: Spec
 spec = describe "Trisagion.Examples.Table tests" $ do
     spec_parseHeader
     spec_parseComment
+    spec_parseFieldOrComment
+    spec_parseRow
     spec_parseFields
 
 
@@ -67,6 +69,71 @@ spec_parseComment = describe "parseComment" $ do
             (Text.pack "#some arbitrary text")
             (Text.pack "some arbitrary text")
             Text.empty
+
+spec_parseFieldOrComment :: Spec
+spec_parseFieldOrComment = describe "parseFieldOrComment" $ do
+    it "Success on comment" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "#some arbitrary text")
+            (Left $ Text.pack "some arbitrary text")
+            Text.empty
+
+    it "Success on field" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "some #arbitrary text")
+            (Right $ Text.pack "some")
+            (Text.pack " #arbitrary text")
+
+    it "Success on whitespace" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "    ")
+            (Right Text.empty)
+            (Text.pack "    ")
+
+    it "No input" $ do
+        testSuccess
+            parseFieldOrComment
+            Text.empty
+            (Right Text.empty)
+            Text.empty
+
+spec_parseRow :: Spec
+spec_parseRow = describe "parseRow" $ do
+    it "Success in case of only whitespace line" $ do
+        testTableSuccess
+            parseRow
+            "    "
+            []
+            (1, "")
+
+    it "Success in case of comment line" $ do
+        testTableSuccess
+            parseRow
+            "#a commentary"
+            []
+            (1, "")
+
+        testTableSuccess
+            parseRow
+            "     #a commentary"
+            []
+            (1, "")
+
+    it "Success case for fields" $ do
+        testTableSuccess
+            parseRow
+            "    some name"
+            (Text.pack <$> ["some", "name"])
+            (1, "")
+
+        testTableSuccess
+            parseRow
+            "    some name #some commentary"
+            (Text.pack <$> ["some", "name"])
+            (1, "")
 
 spec_parseFields :: Spec
 spec_parseFields = describe "parseFields" $ do

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -16,6 +16,9 @@ import Trisagion.Examples.Table
 -- Libraries.
 import qualified Data.Text as Text (pack, empty)
 
+-- Base.
+import Data.List.NonEmpty (NonEmpty (..))
+
 -- Package.
 import Trisagion.Getters.Streamable (InputError (..), MatchError (..) )
 
@@ -141,39 +144,39 @@ spec_parseFields = describe "parseFields" $ do
         testTableSuccess
             parseFields
             "some arbitrary text"
-            (Text.pack <$> ["some", "arbitrary", "text"])
+            (Text.pack <$> ("some" :| ["arbitrary", "text"]))
             (1, "")
 
     it "Success with leading whitespace" $ do
         testTableSuccess
             parseFields
             " \r\v\t\f   some arbitrary text"
-            (Text.pack <$> ["some", "arbitrary", "text"])
-            (1, "")
-
-    it "Success with empty line" $ do
-        testTableSuccess
-            parseFields
-            "    "
-            []
+            (Text.pack <$> ("some" :| ["arbitrary", "text"]))
             (1, "")
 
     it "Success with comment character" $ do
         testTableSuccess
             parseFields
-            "some #arbitrary text"
-            (Text.pack <$> ["some", "#arbitrary", "text"])
+            "some #arbitrary omment"
+            (Text.pack <$> ("some" :| []))
             (1, "")
 
         testTableSuccess
             parseFields
             "some arbi##trary text"
-            (Text.pack <$> ["some", "arbi##trary", "text"])
+            (Text.pack <$> ("some" :| ["arbi##trary", "text"]))
             (1, "")
 
     it "Failure on no input" $ do
         testTableError
             parseFields
             ""
-            (InputError 1)
+            (Left $ InputError 1)
             (0, "")
+
+    it "Failure on empty list of fields" $ do
+        testTableError
+            parseFields
+            "    #some arbitrary comment"
+            (Right FieldsError)
+            (0, "    #some arbitrary comment")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -21,6 +21,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 
 -- Package.
 import Trisagion.Getters.Streamable (InputError (..), MatchError (..) )
+import Data.Foldable (Foldable(..))
 
 
 -- Main module test driver.
@@ -31,6 +32,7 @@ spec = describe "Trisagion.Examples.Table tests" $ do
     spec_parseFieldOrComment
     spec_parseRow
     spec_parseFields
+    spec_parseTable
 
 
 -- Tests.
@@ -180,3 +182,33 @@ spec_parseFields = describe "parseFields" $ do
             "    #some arbitrary comment"
             (Right EmptyLineError)
             (0, "    #some arbitrary comment")
+
+spec_parseTable :: Spec
+spec_parseTable = describe "parseTable" $ do
+    it "Failure on no input" $ do
+        testTableError
+            parseTable
+            ""
+            HeaderError
+            (0, "")
+
+    it "Failure on incorrect signature" $ do
+        testTableError
+            parseTable
+            "incorrect signature"
+            HeaderError
+            (0, "incorrect signature")
+
+    it "Success with empty list of rows" $ do
+        testTableSuccess
+            parseTable
+            "tbl-v1.0\nsome arbitrary field"
+            []
+            (2, "")
+
+    it "Success case" $ do
+        testTableSuccess
+            (fmap (fmap snd. toList) <$> parseTable)
+            "tbl-v1.0\nsome arbitrary field\n1 2 3\n2 1 4"
+            [Text.pack <$> ["1", "2", "3"], Text.pack <$> ["2", "1", "4"]]
+            (4, "")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -15,7 +15,6 @@ import Trisagion.Examples.Table
 
 -- Libraries.
 import qualified Data.Text as Text (pack, empty)
-import Data.Void (Void)
 
 
 -- Main module test driver.
@@ -39,21 +38,21 @@ spec_parseHeader = describe "parseHeader" $ do
         testTableError
             parseHeader
             "some arbitrary text\nsome more text"
-            (HeaderError :: TableError Void)
+            SignatureError
             (0, "some arbitrary text")
 
     it "Failure on leading whitespace" $ do
         testTableError
             parseHeader
             "   tbl-v1.0\nsome more text"
-            (HeaderError :: TableError Void)
+            SignatureError
             (0, "   tbl-v1.0")
 
     it "Failure on wrong casing" $ do
         testTableError
             parseHeader
             "TBL-v1.0\nsome more text"
-            (HeaderError :: TableError Void)
+            SignatureError
             (0, "TBL-v1.0")
 
 spec_parseComment :: Spec

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -178,5 +178,5 @@ spec_parseFields = describe "parseFields" $ do
         testTableError
             parseFields
             "    #some arbitrary comment"
-            (Right FieldsError)
+            (Right EmptyLineError)
             (0, "    #some arbitrary comment")

--- a/tests/Tests/Getters/CharSpec.hs
+++ b/tests/Tests/Getters/CharSpec.hs
@@ -23,6 +23,7 @@ spec = describe "Trisagion.Getters.Char tests" $ do
     spec_lf
     spec_cr
     spec_spaces
+    spec_notSpaces
     spec_sign
     spec_positive
     spec_signed
@@ -106,6 +107,29 @@ spec_spaces = describe "spaces" $ do
     it "No input" $ do
         testSuccess
             spaces
+            ""
+            ""
+            ""
+
+spec_notSpaces :: Spec
+spec_notSpaces = describe "notSpaces" $ do
+    it "Success case" $ do
+        testSuccess
+            notSpaces
+            "0123"
+            "0123"
+            ""
+
+    it "Success on leadinhg whitespace" $ do
+        testSuccess
+            notSpaces
+            "    0123"
+            ""
+            "    0123"
+
+    it "No input" $ do
+        testSuccess
+            notSpaces
             ""
             ""
             ""

--- a/tests/Tests/Getters/CharSpec.hs
+++ b/tests/Tests/Getters/CharSpec.hs
@@ -89,6 +89,13 @@ spec_spaces = describe "spaces" $ do
             "  \t "
             "0123"
 
+    it "Success cases with chars other than space and tab" $ do
+        testSuccess
+            spaces
+            "\v\f\r\n0123"
+            "\v\f\r\n"
+            "0123"
+
     it "No leading whitespace" $ do
         testSuccess
             spaces

--- a/tests/Tests/Getters/CharSpec.hs
+++ b/tests/Tests/Getters/CharSpec.hs
@@ -19,7 +19,7 @@ import Trisagion.Getters.Streamable (InputError (..), MatchError (..), Validatio
 
 -- Main module test driver.
 spec :: Spec
-spec = describe "Bins.Getters.Char tests" $ do
+spec = describe "Trisagion.Getters.Char tests" $ do
     spec_lf
     spec_cr
     spec_spaces

--- a/tests/Tests/Getters/CombinatorsSpec.hs
+++ b/tests/Tests/Getters/CombinatorsSpec.hs
@@ -24,7 +24,7 @@ import Trisagion.Getters.Streamable
 
 -- Main module test driver.
 spec :: Spec
-spec = describe "Bins.Getters.Combinators tests" $ do
+spec = describe "Trisagion.Getters.Combinators tests" $ do
     spec_observe
     spec_lookAhead
     spec_option

--- a/tests/Tests/Getters/SplittableSpec.hs
+++ b/tests/Tests/Getters/SplittableSpec.hs
@@ -19,7 +19,7 @@ import Trisagion.Getters.Streamable (InputError (..), MatchError (..), Validatio
 
 -- Main module test driver.
 spec :: Spec
-spec = describe "Bins.Getters.Splittable tests" $ do
+spec = describe "Trisagion.Getters.Splittable tests" $ do
     spec_takePrefix
     spec_dropPrefix
     spec_takeExact

--- a/tests/Tests/Getters/StreamableSpec.hs
+++ b/tests/Tests/Getters/StreamableSpec.hs
@@ -19,7 +19,7 @@ import Trisagion.Types.ParseError (makeParseError)
 
 -- Main module test driver.
 spec :: Spec
-spec = describe "Bins.Getters.Streamable tests" $ do
+spec = describe "Trisagion.Getters.Streamable tests" $ do
     spec_eoi
     spec_one
     spec_peek

--- a/tests/Tests/Getters/Word8Spec.hs
+++ b/tests/Tests/Getters/Word8Spec.hs
@@ -22,7 +22,7 @@ import Trisagion.Getters.Streamable (InputError (..))
 
 -- Main module test driver.
 spec :: Spec
-spec = describe "Bins.Getters.Streamable tests" $ do
+spec = describe "Trisagion.Getters.Word8 tests" $ do
     spec_word8
     spec_int8
     spec_word32Le

--- a/tests/Tests/Helpers.hs
+++ b/tests/Tests/Helpers.hs
@@ -19,7 +19,7 @@ import Data.Void (Void)
 
 -- Libraries.
 import Data.Text (Text)
-import qualified Data.Text as Text (pack)
+import qualified Data.Text as Text (pack, null)
 
 -- Package.
 import Trisagion.Types.Result (Result (..), withResult)
@@ -85,8 +85,10 @@ testTableSuccess
     -> (Word, String)   -- ^ Stream position and first line of updated state.
     -> Expectation
 testTableSuccess p input ok (offset, out) =
-    let r = extractSuccess $ run p (initLines $ Text.pack input) in
-        r `shouldBe` Just (ok, (offset, Just $ Text.pack out))
+        let r = extractSuccess $ run p (initLines $ Text.pack input) in
+            r `shouldBe` Just (ok, (offset, justIfNotNull $ Text.pack out))
+    where
+        justIfNotNull text = if Text.null text then Nothing else Just text
 
 {- | Test table parser errors by testing error equality via @'shouldBe'@. -}
 testTableError
@@ -97,5 +99,7 @@ testTableError
     -> (Word, String)                       -- ^ Error state component.
     -> Expectation
 testTableError p input err (offset, out) =
-    let r = extractParseError $ run p (initLines $ Text.pack input) in
-        r `shouldBe` Just (err, (offset, Just $ Text.pack out))
+        let r = extractParseError $ run p (initLines $ Text.pack input) in
+            r `shouldBe` Just (err, (offset, justIfNotNull $ Text.pack out))
+    where
+        justIfNotNull text = if Text.null text then Nothing else Just text

--- a/tests/Tests/Helpers.hs
+++ b/tests/Tests/Helpers.hs
@@ -3,19 +3,31 @@ module Tests.Helpers (
     testSuccess,
     testError,
     testFail,
+
+    -- * Table parsers test helpers.
+    testTableSuccess,
+    testTableError,
 ) where
 
 -- Imports.
 -- Testing.
 import Test.Hspec
 
--- Libraries.
+-- Base.
+import Data.Maybe (listToMaybe)
 import Data.Void (Void)
 
+-- Libraries.
+import Data.Text (Text)
+import qualified Data.Text as Text (pack)
+
 -- Package.
-import Trisagion.Types.Result (Result(..))
-import Trisagion.Types.ParseError (ParseError (..))
+import Trisagion.Types.Result (Result (..), withResult)
+import Trisagion.Types.ParseError (ParseError (..), getTag, getState)
+import Trisagion.Streams.Streamable (getStream, getOffset)
 import Trisagion.Get (Get, run)
+import Trisagion.Examples.Table (Lines, initLines)
+import Data.Bifunctor (Bifunctor(..))
 
  
 {- | Test parser success by testing success equality via @'shouldBe'@. -}
@@ -47,3 +59,43 @@ testFail
     -> s                            -- ^ Parser input
     -> Expectation
 testFail p input = run p input `shouldBe` Error Fail
+
+{- | Extract data for success results of @'Get' 'Lines'@ parsers. -}
+extractSuccess :: Result Lines e a -> Maybe (a, (Word, Maybe Text))
+extractSuccess =
+    withResult
+        (const Nothing)
+        (\ ls x -> Just (x, (getOffset ls, listToMaybe $ getStream ls)))
+
+{- | Extract data for error results of @'Get' 'Lines'@ parsers. -}
+extractParseError :: Result Lines (ParseError Lines e) a -> Maybe (e, (Word, Maybe Text))
+extractParseError = withResult processError (\ _ _ -> Nothing)
+    where
+        processError :: ParseError Lines e -> Maybe (e, (Word, Maybe Text))
+        processError err =
+            let mpair = liftA2 (,) (getTag err) (getState err) in
+                second (\ ls -> (getOffset ls, listToMaybe $ getStream ls)) <$> mpair
+
+{- | Test parser success by testing success equality via @'shouldBe'@. -}
+testTableSuccess
+    :: (Show a, Eq a)
+    => Get Lines e a    -- ^ Parser to test.
+    -> String           -- ^ Parser input. 
+    -> a                -- ^ Parsed result.
+    -> (Word, String)   -- ^ Stream position and first line of updated state.
+    -> Expectation
+testTableSuccess p input ok (offset, out) =
+    let r = extractSuccess $ run p (initLines $ Text.pack input) in
+        r `shouldBe` Just (ok, (offset, Just $ Text.pack out))
+
+{- | Test table parser errors by testing error equality via @'shouldBe'@. -}
+testTableError
+    :: (Show e, Eq e)
+    => Get Lines (ParseError Lines e) a     -- ^ Parser to test.
+    -> String                               -- ^ Parser input.
+    -> e                                    -- ^ Error tag.
+    -> (Word, String)                       -- ^ Error state component.
+    -> Expectation
+testTableError p input err (offset, out) =
+    let r = extractParseError $ run p (initLines $ Text.pack input) in
+        r `shouldBe` Just (err, (offset, Just $ Text.pack out))

--- a/trisagion.cabal
+++ b/trisagion.cabal
@@ -29,6 +29,7 @@ common common-fields
     build-depends:
         -- GHC 9.6
         base ^>=4.18 && <4.19,
+        text >=2.0 && <2.2,
     ghc-options:
         -Wall
         -Wcompat
@@ -49,7 +50,6 @@ library
     build-depends:
         mtl >=2.3 && <2.4,
         mono-traversable >=1.0 && <1.1,
-        text >=2.0 && <2.2,
         bytestring >=0.11 && <0.13,
         containers >=0.6 && <0.8,
         vector >=0.13 && <0.14,
@@ -88,3 +88,4 @@ test-suite trisagion-tests
         Tests.Getters.SplittableSpec
         Tests.Getters.Word8Spec
         Tests.Getters.CharSpec
+        Tests.Examples.TableSpec

--- a/trisagion.cabal
+++ b/trisagion.cabal
@@ -68,6 +68,7 @@ library
         Trisagion.Getters.Splittable
         Trisagion.Getters.Word8
         Trisagion.Getters.Char
+        Trisagion.Examples.Table
 
 test-suite trisagion-tests
     import: common-fields

--- a/trisagion.cabal
+++ b/trisagion.cabal
@@ -25,6 +25,7 @@ common common-fields
     default-language: GHC2021
     default-extensions:
         DerivingStrategies
+        DerivingVia
         TypeFamilies
     build-depends:
         -- GHC 9.6


### PR DESCRIPTION
An extended example for parsing a tabular format with whitespace as separator, allowing empty lines and comments. Ended up making a whole sleuth of (relatively minor) changes to other files.