### PR TITLE
The great renaming, part I

### DIFF
--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -48,7 +48,8 @@ import Trisagion.Lib.NonEmpty (zipExact)
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (validate, option, onParseError)
+import Trisagion.Getters.Combinators (validate, onParseError)
+import qualified Trisagion.Getters.Combinators as Getters (maybe)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
 import Trisagion.Getters.Splittable (remainder)
 import Trisagion.Getters.Char (notSpaces, spaces)
@@ -100,7 +101,7 @@ parseComment = matchElem '#' *> first absurd remainder
 
 {- | Parser for a either a comment or a field in a .tbl row. -}
 parseFieldOrComment :: Get Text Void (Either Text Text)
-parseFieldOrComment = option parseComment >>= maybe (Right <$> notSpaces) (pure . Left)
+parseFieldOrComment = Getters.maybe parseComment >>= maybe (Right <$> notSpaces) (pure . Left)
 
 {- | Parser for a .tbl table row. -}
 parseRow :: Get Lines (ParseError Lines InputError) [Text]
@@ -126,7 +127,7 @@ parseRows fields = go
     where
         go = do
             s <- get
-            r <- first absurd $ option parseRow
+            r <- first absurd $ Getters.maybe parseRow
             case r of
                 Nothing -> pure []
                 Just ts ->

--- a/src/Trisagion/Getters/Char.hs
+++ b/src/Trisagion/Getters/Char.hs
@@ -25,7 +25,7 @@ module Trisagion.Getters.Char (
 
 -- Imports.
 -- Base.
-import Data.Bifunctor (Bifunctor(..))
+import Data.Bifunctor (Bifunctor (..))
 import Data.Char (isDigit, ord, isSpace)
 import Data.Foldable (foldl')
 import Data.Maybe (fromMaybe)
@@ -39,7 +39,8 @@ import Trisagion.Typeclasses.Streamable (Streamable)
 import Trisagion.Typeclasses.Splittable (Splittable (..))
 import Trisagion.Types.ParseError (ParseError)
 import Trisagion.Get (Get)
-import Trisagion.Getters.Combinators (validate, option)
+import Trisagion.Getters.Combinators (validate)
+import qualified Trisagion.Getters.Combinators as Getters (maybe)
 import Trisagion.Getters.Streamable (InputError, MatchError, ValidationError (..), matchElem, satisfy, one) 
 import Trisagion.Getters.Splittable (takeWith, atLeastOneWith)
 
@@ -107,7 +108,7 @@ signed
     => Get s (ParseError s (Either InputError ValidationError)) Word
     -> Get s (ParseError s (Either InputError ValidationError)) Int
 signed p = do
-    sgn <- first absurd (fromMaybe Positive <$> option sign)
+    sgn <- first absurd (fromMaybe Positive <$> Getters.maybe sign)
     number <- fromIntegral <$> p
     if sgn == Positive
         then pure number

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -8,11 +8,11 @@ module Trisagion.Getters.Combinators (
     -- * Parsers without errors.
     observe,
     lookAhead,
-    option,
+    maybe,
 
     -- * Handling t'ParseError'.
     validate,
-    onParseErrorWith,
+    backtrackParseError,
     onParseError,
 
     -- * Parsers without values.
@@ -20,8 +20,10 @@ module Trisagion.Getters.Combinators (
     skip,
 
     -- * Applicative parsers.
-    pair,
-    pairWith,
+    zip,
+    zipWith,
+    before,
+    after,
     between,
 
     -- * Alternative parsers.
@@ -29,21 +31,24 @@ module Trisagion.Getters.Combinators (
     choose,
 
     -- * List parsers.
-    chain,
-    repeatN,
+    sequence,
+    repeat,
     unfold,
-    repeatedly,
+    many,
+    some,
     atMostN,
-    atLeastOne,
-    manyTill,
-    manyTill_,
+    until,
+    untilEnd,
     sepBy,
     sepBy1,
 ) where
 
 -- Imports.
+-- Prelude hiding.
+import Prelude hiding (maybe, repeat, sequence, until, zip, zipWith)
+
 -- Base.
-import Control.Applicative (Alternative (..), asum)
+import Control.Applicative (Alternative ((<|>)), asum)
 import Control.Monad (replicateM)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Data (Typeable)
@@ -58,7 +63,7 @@ import Control.Monad.Except (MonadError (..))
 import Control.Monad.State (MonadState (..))
 
 -- Package.
-import Trisagion.Types.ParseError (ParseError (..), initial, makeParseError)
+import Trisagion.Types.ParseError (ParseError (..), initial, makeParseError, mapWith)
 import Trisagion.Get (Get, handleError, eval)
 
 
@@ -78,13 +83,13 @@ lookAhead p = eval p <$> first absurd get
 
 The difference with @'Control.Applicative.optional'@ is the more precise type signature.
 -}
-option :: Get s e a -> Get s Void (Maybe a)
-option p = either (const Nothing) Just <$> observe p
+maybe :: Get s e a -> Get s Void (Maybe a)
+maybe p = either (const Nothing) Just <$> observe p
 
 {- | Run parser and return the result, validating it. -}
 validate
     :: (a -> Either d b)            -- ^ Validator.
-    -> Get s (ParseError s e) a     -- ^ Parser to run and validate.
+    -> Get s (ParseError s e) a     -- ^ Parser to run.
     -> Get s (ParseError s (Either e d)) b
 validate v p = do
     s <- get
@@ -94,19 +99,17 @@ validate v p = do
         pure
         (v r)
 
-{- | Add error context to a parser. -}
-onParseErrorWith
-    :: (Show d, Eq d, Typeable d)
-    => s                            -- ^ State component of the error to throw.
-    -> e                            -- ^ Error tag for contextual error.
-    -> Get s (ParseError s d) a     -- ^ Parser to try.
+{- | Backtrack the parser state component of a thrown 'ParseError'. -}
+backtrackParseError
+    :: Get s (ParseError s e) a
     -> Get s (ParseError s e) a
-onParseErrorWith s err p = do
-    handleError
-        p
-        (\ e -> throwError $ ParseError (Just e) s err)
+backtrackParseError p = do
+        s <- get
+        handleError
+            p
+            (\ err -> throwError $ mapWith id (const s) id err)
 
-{- | Specialized version of 'onParseErrorWith' capturing the current parser state. -}
+{- | Add error context to a 'ParseError'. -}
 onParseError
     :: (Show d, Eq d, Typeable d)
     => e                            -- ^ Error tag for contextual error.
@@ -114,7 +117,9 @@ onParseError
     -> Get s (ParseError s e) a
 onParseError err p = do
     s <- get
-    onParseErrorWith s err p
+    handleError
+        p
+        (\ d -> throwError $ ParseError (Just d) s err)
 
 {- | The parser @failIff p@ fails if and only if @p@ succeeds.
 
@@ -122,14 +127,14 @@ The parser does not consume input and throws a @t'ParseError' s 'Void'@ if @p@ s
 
 note(s):
 
-    * This parser can be used to implement the longest match rule -- see 'manyTill' below.
+    * This parser can be used to implement the longest match rule -- see 'until' below.
 -}
 failIff :: Get s e a -> Get s (ParseError s Void) ()
-failIff p = do
-    r <- first absurd (lookAhead p)
-    case r of
-        Left _  -> pure ()
-        Right _ -> second absurd $ throwError mempty
+failIff p =
+    first absurd (lookAhead p) >>=
+        either
+            (const $ pure ())
+            (const . second absurd $ throwError mempty)
 
 {- | Run the parser but discard the result.
 
@@ -142,12 +147,26 @@ skip :: Get s e a -> Get s e ()
 skip = (() <$)
 
 {- | Sequence two parsers and zip the results in a pair. -}
-pair :: Get s e a -> Get s e b -> Get s e (a, b)
-pair = pairWith (,)
+zip :: Get s e a -> Get s e b -> Get s e (a, b)
+zip = zipWith (,)
 
 {- | Sequence two parsers and zip the results with a binary function. -}
-pairWith :: (a -> b -> c) -> Get s e a -> Get s e b -> Get s e c
-pairWith f p q = f <$> p <*> q
+zipWith :: (a -> b -> c) -> Get s e a -> Get s e b -> Get s e c
+zipWith f p q = f <$> p <*> q
+
+{- | The parser @'before' b p@ parses @b@ and @p@ in succession, returning the result of @p@. -}
+before
+    :: Get s e b                -- ^ Parser to run first.
+    -> Get s e a                -- ^ Parser to run second.
+    -> Get s e a
+before b p = b *> p
+
+{- | The parser @'after' a p@ parses @p@ and @a@ in succession, returning the result of @p@. -}
+after
+    :: Get s e b                -- ^ Parser to run after.
+    -> Get s e a                -- ^ Parser to run first.
+    -> Get s e a
+after a p = p <* a
 
 {- | The parser @'between' o c p@ parses @o@, @p@ and @c@ in succession, returning the result of @p@. -}
 between
@@ -155,7 +174,7 @@ between
     -> Get s e c                -- ^ Closing parser.
     -> Get s e a                -- ^ Parser to run in-between.
     -> Get s e a
-between open close p = open *> p <* close
+between open close = before open . after close
 
 {- | Run the first parser and if it fails run the second. Return the result as an @'Either'@.
 
@@ -170,45 +189,52 @@ eitherOf q p = (Left <$> q) <|> (Right <$> p)
 choose :: (Foldable t, Monoid e) => t (Get s e a) -> Get s e a
 choose = asum
 
-{- | Chain together a traversable of parsers and return the results. -}
-chain :: Traversable t => t (Get s e a) -> Get s e (t a)
-chain = sequenceA
+{- | Sequence a traversable of parsers and return the traversable of results. -}
+sequence :: Traversable t => t (Get s e a) -> Get s e (t a)
+sequence = sequenceA
 
 {- | Run the parser @n@ times and return the list of results.
 
 It is guaranteed that the list of results has exactly @n@ elements.
 -}
-repeatN :: Word -> Get s e a -> Get s e [a]
-repeatN = replicateM . fromIntegral
+repeat :: Word -> Get s e a -> Get s e [a]
+repeat = replicateM . fromIntegral
 
 {- | Lift @'List.unfoldr'@ over the @t'Get'@ monad. -}
 unfold :: (r -> Get s e (a, r)) -> r -> Get s Void [a]
 unfold h = go
     where
         go s = do
-            r <- option (h s)
+            r <- maybe (h s)
             case r of
                 Nothing     -> pure []
                 Just (x, t) -> (x : ) <$> go t
 
-{- | Repeatedly run the parser until it fails, returning the list of results.
+{- | Run the parser zero or more times until it fails, returning the list of results.
 
-The difference with @'many'@ from @'Alternative'@ is the more precise type signature.
+The difference with @'Control.Applicative.many'@ is the more precise type signature.
 
 note(s):
 
-    * The @'repeatedly' p@ parser can loop forever if fed a parser @p@ that does not fail and that
+    * The @'many' p@ parser can loop forever if fed a parser @p@ that does not fail and that
     may not consume input, e.g. any parser with @'Void'@ in the error type or their polymorphic
-    variants, like @'pure' x@, @'many' p@, etc.
+    variants, like @'pure' x@, @'Control.Applicative.many' p@, etc.
 -}
-repeatedly :: Get s e a -> Get s Void [a]
-repeatedly p = go
+many :: Get s e a -> Get s Void [a]
+many p = go
     where
         go = do
-            r <- option p
+            r <- maybe p
             case r of
                 Nothing -> pure []
                 Just x  -> (x :) <$> go
+
+{- | Run the parser one or more times and return the results as a @'NonEmpty'@.
+
+The difference with @'Control.Applicative.some'@ is the more precise type signature.
+-}
+some :: Get s e a -> Get s e (NonEmpty a)
+some p = zipWith (:|) p (first absurd $ many p)
 
 {- | Run the parser @n@ times or until it errors and return the list of results.
 
@@ -219,29 +245,22 @@ atMostN n p = go n
     where
         go 0 = pure []
         go i = do
-            r <- option p
+            r <- maybe p
             case r of
                 Nothing -> pure []
-                Just x  -> (x :) <$> go (i - 1)
+                Just x  -> (x :) <$> go (pred i)
 
-{- | Run the parser one or more times and return the results as a @'NonEmpty'@.
-
-The difference with @'some'@ from 'Alternative' is the more precise type signature.
--}
-atLeastOne :: Get s e a -> Get s e (NonEmpty a)
-atLeastOne p = pairWith (:|) p (first absurd $ repeatedly p)
-
-{- | The parser @'manyTill' end p@ runs @p@ zero or more times until @end@ succeeds. -}
-manyTill
+{- | The parser @'until' end p@ runs @p@ zero or more times until @end@ succeeds. -}
+until
     :: Monoid e
     => Get s e b                -- ^ Closing parser.
     -> Get s e a                -- ^ Parser to run.
     -> Get s Void [a]
-manyTill end p = repeatedly $ first initial (failIff end) *> p
+until end p = many $ first initial (failIff end) *> p
 
-{- | The parser @'manyTill_' end p@ runs @p@ zero or more times until @end@ succeeds, returning the results of @p@ and @end@. -}
-manyTill_ :: Monoid e => Get s e a -> Get s e a -> Get s e (NonEmpty a)
-manyTill_ end p = go
+{- | The parser @'untilEnd' end p@ runs @p@ zero or more times until @end@ succeeds, returning the results of @p@ and @end@. -}
+untilEnd :: Monoid e => Get s e a -> Get s e a -> Get s e (NonEmpty a)
+untilEnd end p = go
     where
         go = do
             r <- eitherOf end p
@@ -251,8 +270,8 @@ manyTill_ end p = go
 
 {- | The parser @'sepBy sep p'@ parses zero or more occurences of @p@ separated by @sep@. -}
 sepBy :: Get s e a -> Get s e b -> Get s Void [b]
-sepBy sep p = fromMaybe [] <$> option (toList <$> sepBy1 sep p)
+sepBy sep p = fromMaybe [] <$> maybe (toList <$> sepBy1 sep p)
 
 {- | The parser @'sepBy sep p'@ parses one or more occurences of @p@ separated by @sep@. -}
 sepBy1 :: Get s e a -> Get s e b -> Get s e (NonEmpty b)
-sepBy1 sep p = pairWith (:|) p (first absurd $ repeatedly (sep *> p))
+sepBy1 sep p = zipWith (:|) p (first absurd $ many (sep *> p))

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -17,11 +17,12 @@ import Trisagion.Examples.Table
 import qualified Data.Text as Text (pack, empty)
 
 -- Base.
+import Data.Bifunctor (Bifunctor (..))
+import Data.Foldable (Foldable (..))
 import Data.List.NonEmpty (NonEmpty (..))
 
 -- Package.
 import Trisagion.Getters.Streamable (InputError (..), MatchError (..) )
-import Data.Foldable (Foldable(..))
 
 
 -- Main module test driver.
@@ -208,7 +209,10 @@ spec_parseTable = describe "parseTable" $ do
 
     it "Success case" $ do
         testTableSuccess
-            (fmap (fmap snd. toList) <$> parseTable)
+            (fmap toList <$> parseTable)
             "tbl-v1.0\nsome arbitrary field\n1 2 3\n2 1 4"
-            [Text.pack <$> ["1", "2", "3"], Text.pack <$> ["2", "1", "4"]]
+            [
+                bimap Text.pack Text.pack <$> [("some","1"), ("arbitrary","2"), ("field","3")],
+                bimap Text.pack Text.pack <$> [("some","2"), ("arbitrary","1"), ("field","4")]
+            ]
             (4, "")

--- a/tests/Tests/Getters/CombinatorsSpec.hs
+++ b/tests/Tests/Getters/CombinatorsSpec.hs
@@ -12,6 +12,7 @@ import Tests.Helpers
 
 -- Module to test.
 import Trisagion.Getters.Combinators
+import qualified Trisagion.Getters.Combinators as Getters (maybe, repeat, sequence, until, zip, zipWith)
 
 -- Base.
 import Data.Bifunctor (Bifunctor(..))
@@ -27,19 +28,20 @@ spec :: Spec
 spec = describe "Trisagion.Getters.Combinators tests" $ do
     spec_observe
     spec_lookAhead
-    spec_option
+    spec_maybe
+    spec_validate
     spec_failIff
-    spec_pair
-    spec_pairWith
+    spec_zip
+    spec_zipWith
     spec_between
     spec_eitherOf
-    spec_chain
-    spec_repeatN
-    spec_repeatedly
+    spec_sequence
+    spec_repeat
+    spec_many
+    spec_some
     spec_atMostN
-    spec_atLeastOne
-    spec_manyTill
-    spec_manyTill_
+    spec_until
+    spec_untilEnd
     spec_sepBy1
 
 
@@ -90,28 +92,60 @@ spec_lookAhead = describe "lookAhead" $ do
             (Left $ makeParseError "" (InputError 1))
             ""
 
-spec_option :: Spec
-spec_option = describe "option" $ do
+spec_maybe :: Spec
+spec_maybe = describe "maybe" $ do
     it "Success case" $ do
         testSuccess
-            (option $ matchElem '0')
+            (Getters.maybe $ matchElem '0')
             "0123"
             (Just '0')
             "123"
 
     it "Failure case" $ do
         testSuccess
-            (option $ matchElem '1')
+            (Getters.maybe $ matchElem '1')
             "0123"
             Nothing
             "0123"
 
     it "End of input case" $ do
         testSuccess
-            (option $ matchElem '0')
+            (Getters.maybe $ matchElem '0')
             ""
             Nothing
             ""
+
+spec_validate :: Spec
+spec_validate = describe "validate" $ do
+    it "Success case" $ do
+        testSuccess
+            (validate (\ c -> if c == '0' then Right c else Left ()) one)
+            "0123"
+            '0'
+            "123"
+
+    it "Case of parser failure" $ do
+         testError
+            (validate (\ c -> if c == '0' then Right c else Left ()) one)
+            ""
+            ""
+            (Left $ InputError 1)
+
+    it "Case of parser failure -- parser state advanced" $ do
+         testError
+            (validate
+                (\ c -> if c == '0' then Right c else Left ())
+                (first (fmap Left) one *> matchElem '1'))
+            "023"
+            "23"
+            (Left $ Right $ MatchError '1')
+
+    it "Case of failed validation -- parser state not advanced" $ do
+         testError
+            (validate (\ c -> if c == '0' then Right c else Left ()) one)
+            "123"
+            "123"
+            (Right $ ())
 
 spec_failIff :: Spec
 spec_failIff = describe "failIff" $ do
@@ -134,35 +168,35 @@ spec_failIff = describe "failIff" $ do
             ()
             ""
 
-spec_pair :: Spec
-spec_pair = describe "pair" $ do
+spec_zip :: Spec
+spec_zip = describe "zip" $ do
     it "Success case" $ do
         testSuccess
-            (pair one one)
+            (Getters.zip one one)
             "0123"
             ('0','1')
             "23"
 
     it "Case of first parser failure" $ do
          testError
-            (pair (matchElem '1') (matchElem '1'))
+            (Getters.zip (matchElem '1') (matchElem '1'))
             "0123"
             "0123"
             (Right $ MatchError '1')
 
     it "Case of second parser failure" $ do
          testError
-            (pair (matchElem '0') (matchElem '2'))
+            (Getters.zip (matchElem '0') (matchElem '2'))
             "0123"
             -- One character consumed.
             "123"
             (Right $ MatchError '2')
 
-spec_pairWith :: Spec
-spec_pairWith = describe "pairWith" $ do
+spec_zipWith :: Spec
+spec_zipWith = describe "zipWith" $ do
     it "Success case" $ do
         testSuccess
-            (pairWith max one one)
+            (Getters.zipWith max one one)
             "0123"
             '1'
             "23"
@@ -237,62 +271,62 @@ spec_eitherOf = describe "eitherOf" $ do
 
     it "Failure of both parsers but with different errors" $ do
         testError
-            (eitherOf (matchElem '1') (bimap (fmap Left) snd $ pair one one))
+            (eitherOf (matchElem '1') (bimap (fmap Left) snd $ Getters.zip one one))
             "0"
             "0"
             (Right $ MatchError '1')
 
-spec_chain :: Spec
-spec_chain = describe "chain" $ do
+spec_sequence :: Spec
+spec_sequence = describe "sequence" $ do
     it "Case of all parsers succeeding" $ do
         testSuccess
-            (chain [matchElem '{', first (fmap Left) one, matchElem '}'])
+            (Getters.sequence [matchElem '{', first (fmap Left) one, matchElem '}'])
             "{1}3"
             "{1}"
             "3"
 
-spec_repeatN :: Spec
-spec_repeatN = describe "repeatN" $ do
+spec_repeat :: Spec
+spec_repeat = describe "repeat" $ do
     it "Success case" $ do
         testSuccess
-            (repeatN 2 one)
+            (Getters.repeat 2 one)
             "0123"
             "01"
             "23"
 
     it "Failure case of insufficient input" $ do
         testError
-            (repeatN 10 one)
+            (Getters.repeat 10 one)
             "0123"
             ""
             (InputError 1)
 
     it "Failure when middle parser fails" $ do
         testError
-            (repeatN 2 (matchElem '0'))
+            (Getters.repeat 2 (matchElem '0'))
             "0123"
             "123"
             (Right $ MatchError '0')
 
-spec_repeatedly :: Spec
-spec_repeatedly = describe "repeatedly" $ do
+spec_many :: Spec
+spec_many = describe "many" $ do
     it "Success case" $ do
         testSuccess
-            (repeatedly (satisfy ('}' /=)))
+            (many (satisfy ('}' /=)))
             "01}3"
             "01"
             "}3"
 
     it "Case of first parser failure" $ do
         testSuccess
-            (repeatedly (satisfy ('0' /=)))
+            (many (satisfy ('0' /=)))
             "0123"
             ""
             "0123"
 
     it "Case of end of input" $ do
         testSuccess
-            (repeatedly (satisfy ('0' /=)))
+            (many (satisfy ('0' /=)))
             ""
             ""
             ""
@@ -320,43 +354,43 @@ spec_atMostN = describe "atMostN" $ do
             "0"
             "123"
 
-spec_atLeastOne :: Spec
-spec_atLeastOne = describe "atLeastOne" $ do
+spec_some :: Spec
+spec_some = describe "some" $ do
     it "Success case" $ do
         testSuccess
-            (atLeastOne (satisfy ('}' /=)))
+            (some (satisfy ('}' /=)))
             "01}3"
             ('0' :| "1")
             "}3"
 
     it "Case when first parser fails" $ do
         testError
-            (atLeastOne (satisfy ('0' /=)))
+            (some (satisfy ('0' /=)))
             "0123"
             "0123"
             (Right ValidationError)
 
-spec_manyTill :: Spec
-spec_manyTill = describe "manyTill" $ do
+spec_until :: Spec
+spec_until = describe "until" $ do
     it "Success case" $ do
         testSuccess
-            (manyTill (matchElem '}') (first (fmap Left) one))
+            (Getters.until (matchElem '}') (first (fmap Left) one))
             "01}3"
             "01"
             "}3"
 
     it "Case of failure of first parser" $ do
         testSuccess
-            (manyTill (matchElem '}') (first (fmap Left) one))
+            (Getters.until (matchElem '}') (first (fmap Left) one))
             "}012"
             ""
             "}012"
 
-spec_manyTill_ :: Spec
-spec_manyTill_ = describe "manyTill_" $ do
+spec_untilEnd :: Spec
+spec_untilEnd = describe "untilEnd" $ do
     it "Success case" $ do
         testSuccess
-            (manyTill_ (matchElem '}') (first (fmap Left) one))
+            (untilEnd (matchElem '}') (first (fmap Left) one))
             "01}3"
             ('0' :| "1}")
             "3"


### PR DESCRIPTION
Renaming some of the combinators to use simpler names, but also conflicting with Prelude names, so Combinators should/must be imported qualified.