### PR TITLE
Undiscriminated changes

### DIFF
--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -6,7 +6,6 @@ Parser for the .tbl tabular format.
 
 module Trisagion.Examples.Table (
     -- * Error types.
-    MismatchError (..),
     TableError (..),
 
     -- * Types.
@@ -17,35 +16,23 @@ module Trisagion.Examples.Table (
 
     -- * Parsers.
     parseTable,
-
-    -- ** Auxiliary parsers.
-    parseRows,
 ) where
 
 -- Imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
-import Data.List.NonEmpty (NonEmpty, nonEmpty)
-import Data.Void (absurd)
+import Data.List.NonEmpty (NonEmpty)
 
 -- Libraries.
-import Control.Monad.Except (MonadError(..))
-import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
 import Data.Vector.Strict (Vector, fromList)
 
 -- Package.
-import Trisagion.Lib.NonEmpty (zipExact)
-import Trisagion.Types.ParseError (ParseError, makeParseError)
+import Trisagion.Types.ParseError (ParseError)
 import Trisagion.Get (Get)
 import Trisagion.Getters.Combinators (onParseError)
-import Trisagion.Getters.Combinators qualified as Getters (maybe)
-import Trisagion.Examples.Table.Parsers (Lines, parseHeader, parseFields, parseLine)
+import Trisagion.Examples.Table.Parsers (Lines, parseHeader, parseFields, parseRows)
 
-
-{- | The @MismatchError@ error type, raised when the number of values and field names are not equal. -}
-data MismatchError = MismatchError
-    deriving stock (Eq, Show)
 
 {- | The @TableError@ error type. -}
 data TableError
@@ -65,24 +52,6 @@ makeTable :: [a] -> Table a
 makeTable = Table . fromList
 
 
-{- | Parser for a non-empty list of .tbl table rows. -}
-parseRows :: NonEmpty Text -> Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
-parseRows fields = go
-    where
-        go = do
-            s <- get
-            r <- first absurd $ Getters.maybe parseLine
-            case r of
-                Nothing -> pure []
-                Just ts ->
-                    case nonEmpty ts of
-                        -- Case of empty line.
-                        Nothing -> go
-                        Just fs ->
-                            case zipExact fields fs of
-                                Nothing -> throwError $ makeParseError s RowError
-                                Just ps -> (ps :) <$> go
-
 {- | Parser for an entire .tbl table. -}
 parseTable
     :: (NonEmpty (Text, Text) -> a)     -- ^ Row conversion function.
@@ -90,4 +59,4 @@ parseTable
 parseTable f = do
         _      <- onParseError HeaderError parseHeader
         fields <- onParseError FieldsError parseFields
-        makeTable . fmap f <$> parseRows fields
+        bimap (fmap (const RowError)) (makeTable . fmap f) $ parseRows fields

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -5,14 +5,7 @@ Parser for the .tbl tabular format.
 -}
 
 module Trisagion.Examples.Table (
-    -- * Streams.
-    Lines,
-
-    -- ** Constructors.
-    initLines,
-
     -- * Error types.
-    EmptyLineError (..),
     MismatchError (..),
     TableError (..),
 
@@ -22,18 +15,10 @@ module Trisagion.Examples.Table (
     -- ** Constructors.
     makeTable,
 
-    -- * Generic parsers.
-    parseLineWith,
-
     -- * Parsers.
     parseTable,
 
     -- ** Auxiliary parsers.
-    parseHeader,
-    parseComment,
-    parseFieldOrComment,
-    parseRow,
-    parseFields,
     parseRows,
 ) where
 
@@ -41,39 +26,22 @@ module Trisagion.Examples.Table (
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
-import Data.Void (Void, absurd)
+import Data.Void (absurd)
 
 -- Libraries.
 import Control.Monad.Except (MonadError(..))
 import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
-import Data.Text qualified as Text (lines, pack, strip, null)
 import Data.Vector.Strict (Vector, fromList)
 
 -- Package.
 import Trisagion.Lib.NonEmpty (zipExact)
-import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
-import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (validate, onParseError)
+import Trisagion.Get (Get)
+import Trisagion.Getters.Combinators (onParseError)
 import Trisagion.Getters.Combinators qualified as Getters (maybe)
-import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
-import Trisagion.Getters.Splittable (remainder)
-import Trisagion.Getters.Char (notSpaces, spaces)
+import Trisagion.Examples.Table.Parsers (Lines, parseHeader, parseFields, parseLine)
 
-
-{- | A type alias for @t'Stream' ['Text']@. -}
-type Lines = Stream [Text]
-
-
-{- | Construct a t'Lines' streamable from @'Text.lines' text@. -}
-initLines :: Text -> Lines
-initLines text = initialize (Text.lines text)
-
-
-{- | The @EmptyLineError@ error type, raised on an empty line. -}
-data EmptyLineError = EmptyLineError
-    deriving stock (Eq, Show)
 
 {- | The @MismatchError@ error type, raised when the number of values and field names are not equal. -}
 data MismatchError = MismatchError
@@ -96,46 +64,6 @@ newtype Table a = Table (Vector a)
 makeTable :: [a] -> Table a
 makeTable = Table . fromList
 
-{- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
-
-note(s):
-
-    * any unconsumed input by the 'Text' parser is discarded.
--}
-parseLineWith
-    :: Get Text e a
-    -> Get Lines (ParseError Lines (Either InputError e)) a
-parseLineWith p = validate (eval p) (Text.strip <$> one)
-
-{- | Parser for the header of a .tbl table. -}
-parseHeader :: Get Lines (ParseError Lines (Either InputError (MatchError Text))) Text
-parseHeader = matchElem (Text.pack "tbl-v1.0")
-
-{- | Parser for a comment in a .tbl row. -}
-parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
-parseComment = matchElem '#' *> first absurd remainder
-
-{- | Parser for a either a comment or a field in a .tbl row. -}
-parseFieldOrComment :: Get Text Void (Either Text Text)
-parseFieldOrComment = Getters.maybe parseComment >>= maybe (Right <$> notSpaces) (pure . Left)
-
-{- | Parser for a .tbl table row. -}
-parseRow :: Get Lines (ParseError Lines InputError) [Text]
-parseRow = first (fmap (either id absurd)) $ parseLineWith go
-    where
-        go :: Get Text Void [Text]
-        go = do
-            r <- spaces *> parseFieldOrComment
-            case r of
-                Left _      -> pure []
-                Right field ->
-                    if Text.null field
-                        then pure []
-                        else (field :) <$> go
-
-{- | Parse one line as a 'NonEmpty' of field names. -}
-parseFields :: Get Lines (ParseError Lines (Either InputError EmptyLineError)) (NonEmpty Text)
-parseFields = validate (maybe (Left EmptyLineError) Right . nonEmpty) parseRow
 
 {- | Parser for a non-empty list of .tbl table rows. -}
 parseRows :: NonEmpty Text -> Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
@@ -143,7 +71,7 @@ parseRows fields = go
     where
         go = do
             s <- get
-            r <- first absurd $ Getters.maybe parseRow
+            r <- first absurd $ Getters.maybe parseLine
             case r of
                 Nothing -> pure []
                 Just ts ->

--- a/src/Trisagion/Examples/Table.hs
+++ b/src/Trisagion/Examples/Table.hs
@@ -16,6 +16,12 @@ module Trisagion.Examples.Table (
     MismatchError (..),
     TableError (..),
 
+    -- * Types.
+    Table,
+
+    -- ** Constructors.
+    makeTable,
+
     -- * Generic parsers.
     parseLineWith,
 
@@ -41,7 +47,8 @@ import Data.Void (Void, absurd)
 import Control.Monad.Except (MonadError(..))
 import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
-import qualified Data.Text as Text (lines, pack, strip, null)
+import Data.Text qualified as Text (lines, pack, strip, null)
+import Data.Vector.Strict (Vector, fromList)
 
 -- Package.
 import Trisagion.Lib.NonEmpty (zipExact)
@@ -49,7 +56,7 @@ import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Types.ParseError (ParseError, makeParseError)
 import Trisagion.Get (Get, eval)
 import Trisagion.Getters.Combinators (validate, onParseError)
-import qualified Trisagion.Getters.Combinators as Getters (maybe)
+import Trisagion.Getters.Combinators qualified as Getters (maybe)
 import Trisagion.Getters.Streamable (one, matchElem, InputError (..), MatchError)
 import Trisagion.Getters.Splittable (remainder)
 import Trisagion.Getters.Char (notSpaces, spaces)
@@ -79,6 +86,15 @@ data TableError
     | RowError
     deriving stock (Eq, Show)
 
+
+{- | The @Table@ type. -}
+newtype Table a = Table (Vector a)
+    deriving stock (Eq, Show, Functor, Foldable, Traversable)
+
+
+{- | Construct a table from a list. -}
+makeTable :: [a] -> Table a
+makeTable = Table . fromList
 
 {- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
 
@@ -140,7 +156,10 @@ parseRows fields = go
                                 Just ps -> (ps :) <$> go
 
 {- | Parser for an entire .tbl table. -}
-parseTable :: Get Lines (ParseError Lines TableError) [NonEmpty (Text, Text)]
-parseTable = do
-        _  <- onParseError HeaderError parseHeader
-        onParseError FieldsError parseFields >>= parseRows
+parseTable
+    :: (NonEmpty (Text, Text) -> a)     -- ^ Row conversion function.
+    -> Get Lines (ParseError Lines TableError) (Table a)
+parseTable f = do
+        _      <- onParseError HeaderError parseHeader
+        fields <- onParseError FieldsError parseFields
+        makeTable . fmap f <$> parseRows fields

--- a/src/Trisagion/Examples/Table/Parsers.hs
+++ b/src/Trisagion/Examples/Table/Parsers.hs
@@ -5,5 +5,92 @@ Parsers for the .tbl tabular format.
 -}
 
 module Trisagion.Examples.Table.Parsers (
+    -- * Streams.
+    Lines,
+
+    -- ** Constructors.
+    initLines,
+
+    -- * Error types.
+    NoFieldsError (..),
+
     -- * Parsers.
+    parseHeader,
+    parseComment,
+    parseFieldOrComment,
+    parseLine,
+    parseFields,
 ) where
+
+-- Imports.
+-- Base.
+import Data.Bifunctor (Bifunctor (..))
+import Data.List.NonEmpty (NonEmpty, nonEmpty)
+import Data.Void (Void, absurd)
+
+-- Libraries.
+import Data.Text (Text)
+import Data.Text qualified as Text (pack, lines, strip, null)
+
+-- Package.
+import Trisagion.Types.ParseError (ParseError)
+import Trisagion.Streams.Streamable (Stream, initialize)
+import Trisagion.Get (Get, eval)
+import Trisagion.Getters.Combinators (validate)
+import Trisagion.Getters.Combinators qualified as Getters (maybe)
+import Trisagion.Getters.Streamable (InputError, MatchError, matchElem, one)
+import Trisagion.Getters.Splittable (remainder)
+import Trisagion.Getters.Char (notSpaces, spaces)
+
+
+{- | A type alias for @t'Stream' ['Text']@. -}
+type Lines = Stream [Text]
+
+
+{- | Construct a t'Lines' streamable from @'Text.lines' text@. -}
+initLines :: Text -> Lines
+initLines text = initialize (Text.lines text)
+
+
+{- | The @NoFieldsError@ error type, raised on a line with no field values. -}
+data NoFieldsError = NoFieldsError
+    deriving stock (Eq, Show)
+
+
+{- | Parser for the header of a .tbl table. -}
+parseHeader :: Get Lines (ParseError Lines (Either InputError (MatchError Text))) Text
+parseHeader = matchElem (Text.pack "tbl-v1.0")
+
+{- | Parser for a comment in a .tbl row. -}
+parseComment :: Get Text (ParseError Text (Either InputError (MatchError Char))) Text
+parseComment = matchElem '#' *> first absurd remainder
+
+{- | Parser for a either a comment or a field in a .tbl row. -}
+parseFieldOrComment :: Get Text Void (Either Text Text)
+parseFieldOrComment = Getters.maybe parseComment >>= maybe (Right <$> notSpaces) (pure . Left)
+
+{- | Parse one line stripped of whitespace on both ends with a 'Text' parser.
+
+note(s):
+
+    * any unconsumed input by the 'Text' parser is silently discarded.
+-}
+parseLineWith
+    :: Get Text e a
+    -> Get Lines (ParseError Lines (Either InputError e)) a
+parseLineWith p = validate (eval p) (Text.strip <$> one)
+
+{- | Parser for a .tbl table row. -}
+parseLine :: Get Lines (ParseError Lines InputError) [Text]
+parseLine = first (fmap (either id absurd)) $ parseLineWith go
+    where
+        go :: Get Text Void [Text]
+        go =
+            spaces *> parseFieldOrComment >>=
+                either
+                    (const $ pure [])
+                    (\ field -> if Text.null field then pure [] else (field :) <$> go)
+
+{- | Parse one line as a 'NonEmpty' of field values. -}
+parseFields :: Get Lines (ParseError Lines (Either InputError NoFieldsError)) (NonEmpty Text)
+parseFields = validate (maybe (Left NoFieldsError) Right . nonEmpty) parseLine

--- a/src/Trisagion/Examples/Table/Parsers.hs
+++ b/src/Trisagion/Examples/Table/Parsers.hs
@@ -1,0 +1,9 @@
+{- |
+Module: Trisagion.Examples.Table.Parsers
+
+Parsers for the .tbl tabular format.
+-}
+
+module Trisagion.Examples.Table.Parsers (
+    -- * Parsers.
+) where

--- a/src/Trisagion/Examples/Table/Parsers.hs
+++ b/src/Trisagion/Examples/Table/Parsers.hs
@@ -13,6 +13,7 @@ module Trisagion.Examples.Table.Parsers (
 
     -- * Error types.
     NoFieldsError (..),
+    MismatchError (..),
 
     -- * Parsers.
     parseHeader,
@@ -20,6 +21,7 @@ module Trisagion.Examples.Table.Parsers (
     parseFieldOrComment,
     parseLine,
     parseFields,
+    parseRows,
 ) where
 
 -- Imports.
@@ -29,14 +31,17 @@ import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Void (Void, absurd)
 
 -- Libraries.
+import Control.Monad.Except (MonadError(..))
+import Control.Monad.State (MonadState(..))
 import Data.Text (Text)
 import Data.Text qualified as Text (pack, lines, strip, null)
 
 -- Package.
-import Trisagion.Types.ParseError (ParseError)
+import Trisagion.Lib.NonEmpty (zipExact)
+import Trisagion.Types.ParseError (ParseError (..), withParseError, makeParseError)
 import Trisagion.Streams.Streamable (Stream, initialize)
 import Trisagion.Get (Get, eval)
-import Trisagion.Getters.Combinators (validate)
+import Trisagion.Getters.Combinators (validate, observe)
 import Trisagion.Getters.Combinators qualified as Getters (maybe)
 import Trisagion.Getters.Streamable (InputError, MatchError, matchElem, one)
 import Trisagion.Getters.Splittable (remainder)
@@ -54,6 +59,10 @@ initLines text = initialize (Text.lines text)
 
 {- | The @NoFieldsError@ error type, raised on a line with no field values. -}
 data NoFieldsError = NoFieldsError
+    deriving stock (Eq, Show)
+
+{- | The @MismatchError@ error type, raised on a line with incorrect number of fields. -}
+data MismatchError = MismatchError
     deriving stock (Eq, Show)
 
 
@@ -94,3 +103,18 @@ parseLine = first (fmap (either id absurd)) $ parseLineWith go
 {- | Parse one line as a 'NonEmpty' of field values. -}
 parseFields :: Get Lines (ParseError Lines (Either InputError NoFieldsError)) (NonEmpty Text)
 parseFields = validate (maybe (Left NoFieldsError) Right . nonEmpty) parseLine
+
+{- | Parser for a list of .tbl table rows. -}
+parseRows :: NonEmpty Text -> Get Lines (ParseError Lines MismatchError) [NonEmpty (Text, Text)]
+parseRows fields = go
+    where
+        go = do
+            s <- get
+            first absurd (observe parseFields) >>=
+                either
+                    (withParseError
+                        (throwError Fail)
+                        (\ _ _ e -> either (const $ pure []) (const go) e))
+                    (\ values -> case zipExact fields values of
+                        Nothing -> throwError $ makeParseError s MismatchError
+                        Just ps -> (ps :) <$> go)

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -107,7 +107,7 @@ backtrackParseError p = do
         s <- get
         handleError
             p
-            (\ err -> throwError $ mapWith id (const s) id err)
+            (throwError . mapWith id (const s) id)
 
 {- | Add error context to a 'ParseError'. -}
 onParseError

--- a/src/Trisagion/Getters/Combinators.hs
+++ b/src/Trisagion/Getters/Combinators.hs
@@ -27,7 +27,7 @@ module Trisagion.Getters.Combinators (
     between,
 
     -- * Alternative parsers.
-    eitherOf,
+    either,
     choose,
 
     -- * List parsers.
@@ -45,7 +45,8 @@ module Trisagion.Getters.Combinators (
 
 -- Imports.
 -- Prelude hiding.
-import Prelude hiding (maybe, repeat, sequence, until, zip, zipWith)
+import Prelude qualified as Base (either)
+import Prelude hiding (either, maybe, repeat, sequence, until, zip, zipWith)
 
 -- Base.
 import Control.Applicative (Alternative ((<|>)), asum)
@@ -84,7 +85,7 @@ lookAhead p = eval p <$> first absurd get
 The difference with @'Control.Applicative.optional'@ is the more precise type signature.
 -}
 maybe :: Get s e a -> Get s Void (Maybe a)
-maybe p = either (const Nothing) Just <$> observe p
+maybe p = Base.either (const Nothing) Just <$> observe p
 
 {- | Run parser and return the result, validating it. -}
 validate
@@ -94,7 +95,7 @@ validate
 validate v p = do
     s <- get
     r <- first (fmap Left) p
-    either
+    Base.either
         (throwError . makeParseError s . Right)
         pure
         (v r)
@@ -132,7 +133,7 @@ note(s):
 failIff :: Get s e a -> Get s (ParseError s Void) ()
 failIff p =
     first absurd (lookAhead p) >>=
-        either
+        Base.either
             (const $ pure ())
             (const . second absurd $ throwError mempty)
 
@@ -182,8 +183,8 @@ note(s):
 
     * The parser is @'Left'@-biased; if the first parser is successful the second never runs.
 -}
-eitherOf :: Monoid e => Get s e a -> Get s e b -> Get s e (Either a b)
-eitherOf q p = (Left <$> q) <|> (Right <$> p)
+either :: Monoid e => Get s e a -> Get s e b -> Get s e (Either a b)
+either q p = (Left <$> q) <|> (Right <$> p)
 
 {- | Run the parsers in succession, returning the result of the first successful one. -}
 choose :: (Foldable t, Monoid e) => t (Get s e a) -> Get s e a
@@ -263,7 +264,7 @@ untilEnd :: Monoid e => Get s e a -> Get s e a -> Get s e (NonEmpty a)
 untilEnd end p = go
     where
         go = do
-            r <- eitherOf end p
+            r <- either end p
             case r of
                 Left e -> pure $ e :| []
                 Right x -> (x <|) <$> go

--- a/tests/Tests/Examples/Table/ParsersSpec.hs
+++ b/tests/Tests/Examples/Table/ParsersSpec.hs
@@ -209,6 +209,13 @@ spec_parseRows = describe "parseRows" $ do
             ]
             (2, "")
 
+    it "Success on no input" $ do
+        testTableSuccess
+            (parseRows (Text.pack <$> ("some" <| singleton "field")))
+            ""
+            []
+            (0, "")
+            
     it "Success with comment lines" $ do
         testTableSuccess
             (parseRows (Text.pack <$> ("some" <| singleton "field")))

--- a/tests/Tests/Examples/Table/ParsersSpec.hs
+++ b/tests/Tests/Examples/Table/ParsersSpec.hs
@@ -1,0 +1,196 @@
+module Tests.Examples.Table.ParsersSpec (
+    -- * Tests.
+    spec,
+) where
+
+-- Imports.
+-- Testing library.
+import Test.Hspec
+
+-- Testing helpers.
+import Tests.Helpers
+
+-- Module to test.
+import Trisagion.Examples.Table.Parsers
+
+-- Auxiliary imports.
+-- Base.
+import Data.List.NonEmpty ((<|), singleton)
+
+-- Libraries.
+import Data.Text qualified as Text (pack, empty)
+
+-- Package.
+import Trisagion.Getters.Streamable (MatchError (..), InputError (..))
+
+
+-- Main module test driver.
+spec :: Spec
+spec = describe "Trisagion.Examples.Table tests" $ do
+    spec_parseHeader
+    spec_parseComment
+    spec_parseFieldOrComment
+    spec_parseLine
+    spec_parseFields
+
+
+spec_parseHeader :: Spec
+spec_parseHeader = describe "parseHeader" $ do
+    it "Success case" $ do
+        testTableSuccess
+            parseHeader
+            "tbl-v1.0\nsome more text"
+            (Text.pack "tbl-v1.0")
+            (1, "some more text")
+
+    it "Failure on mismatch" $ do
+        testTableError
+            parseHeader
+            "some arbitrary text\nsome more text"
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
+            (0, "some arbitrary text")
+
+    it "Failure on leading whitespace" $ do
+        testTableError
+            parseHeader
+            "   tbl-v1.0\nsome more text"
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
+            (0, "   tbl-v1.0")
+
+    it "Failure on wrong casing" $ do
+        testTableError
+            parseHeader
+            "TBL-v1.0\nsome more text"
+            (Right $ MatchError (Text.pack "tbl-v1.0"))
+            (0, "TBL-v1.0")
+
+spec_parseComment :: Spec
+spec_parseComment = describe "parseComment" $ do
+    it "Success case" $ do
+        testSuccess
+            parseComment
+            (Text.pack "#some arbitrary text")
+            (Text.pack "some arbitrary text")
+            Text.empty
+
+    it "Failure on no input" $ do
+        testError
+            parseComment
+            Text.empty
+            Text.empty
+            (Left $ InputError 1)
+
+    it "Failure on incorrect comment starting character" $ do
+        testError
+            parseComment
+            (Text.pack "/comment with wrong character")
+            (Text.pack "/comment with wrong character")
+            (Right $ MatchError '#')
+
+spec_parseFieldOrComment :: Spec
+spec_parseFieldOrComment = describe "parseFieldOrComment" $ do
+    it "Success on comment" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "#some arbitrary text")
+            (Left $ Text.pack "some arbitrary text")
+            Text.empty
+
+    it "Success on field" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "some #arbitrary text")
+            (Right $ Text.pack "some")
+            (Text.pack " #arbitrary text")
+
+    it "Success on whitespace" $ do
+        testSuccess
+            parseFieldOrComment
+            (Text.pack "    ")
+            (Right Text.empty)
+            (Text.pack "    ")
+
+    it "No input" $ do
+        testSuccess
+            parseFieldOrComment
+            Text.empty
+            (Right Text.empty)
+            Text.empty
+
+spec_parseLine :: Spec
+spec_parseLine = describe "parseLine" $ do
+    it "Success in case of only whitespace line" $ do
+        testTableSuccess
+            parseLine
+            "    "
+            []
+            (1, "")
+
+    it "Success in case of comment line" $ do
+        testTableSuccess
+            parseLine
+            "#a commentary"
+            []
+            (1, "")
+
+        testTableSuccess
+            parseLine
+            "     #a commentary"
+            []
+            (1, "")
+
+    it "Success case for fields" $ do
+        testTableSuccess
+            parseLine
+            "    some name"
+            (Text.pack <$> ["some", "name"])
+            (1, "")
+
+        testTableSuccess
+            parseLine
+            "    some name #some commentary"
+            (Text.pack <$> ["some", "name"])
+            (1, "")
+
+spec_parseFields :: Spec
+spec_parseFields = describe "parseFields" $ do
+    it "Success case" $ do
+        testTableSuccess
+            parseFields
+            "some arbitrary text"
+            (Text.pack <$> ("some" <| "arbitrary" <| singleton "text"))
+            (1, "")
+
+    it "Success with leading whitespace" $ do
+        testTableSuccess
+            parseFields
+            " \r\v\t\f   some arbitrary text"
+            (Text.pack <$> ("some" <| "arbitrary" <| singleton "text"))
+            (1, "")
+
+    it "Success with comment character" $ do
+        testTableSuccess
+            parseFields
+            "some #arbitrary omment"
+            (Text.pack <$> singleton "some" )
+            (1, "")
+
+        testTableSuccess
+            parseFields
+            "some arbi##trary text"
+            (Text.pack <$> ("some" <| "arbi##trary" <| singleton "text"))
+            (1, "")
+
+    it "Failure on no input" $ do
+        testTableError
+            parseFields
+            ""
+            (Left $ InputError 1)
+            (0, "")
+
+    it "Failure on empty list of fields" $ do
+        testTableError
+            parseFields
+            "    #some arbitrary comment"
+            (Right NoFieldsError)
+            (0, "    #some arbitrary comment")

--- a/tests/Tests/Examples/Table/ParsersSpec.hs
+++ b/tests/Tests/Examples/Table/ParsersSpec.hs
@@ -15,6 +15,7 @@ import Trisagion.Examples.Table.Parsers
 
 -- Auxiliary imports.
 -- Base.
+import Data.Bifunctor (Bifunctor (..))
 import Data.List.NonEmpty ((<|), singleton)
 
 -- Libraries.
@@ -32,6 +33,7 @@ spec = describe "Trisagion.Examples.Table tests" $ do
     spec_parseFieldOrComment
     spec_parseLine
     spec_parseFields
+    spec_parseRows
 
 
 spec_parseHeader :: Spec
@@ -194,3 +196,32 @@ spec_parseFields = describe "parseFields" $ do
             "    #some arbitrary comment"
             (Right NoFieldsError)
             (0, "    #some arbitrary comment")
+
+spec_parseRows :: Spec
+spec_parseRows = describe "parseRows" $ do
+    it "Success case" $ do
+        testTableSuccess
+            (parseRows (Text.pack <$> ("some" <| singleton "field")))
+            "1 2\n2 1"
+            [
+                bimap Text.pack Text.pack <$> (("some","1") <| singleton ("field","2")),
+                bimap Text.pack Text.pack <$> (("some","2") <| singleton ("field","1"))
+            ]
+            (2, "")
+
+    it "Success with comment lines" $ do
+        testTableSuccess
+            (parseRows (Text.pack <$> ("some" <| singleton "field")))
+            "1 2 #first comment\n2 1 #second comment"
+            [
+                bimap Text.pack Text.pack <$> (("some","1") <| singleton ("field","2")),
+                bimap Text.pack Text.pack <$> (("some","2") <| singleton ("field","1"))
+            ]
+            (2, "")
+
+    it "Failure on mismatched number of fields" $ do
+        testTableError
+            (parseRows (Text.pack <$> ("some" <| singleton "field")))
+            "1 2\n2 1 spurious"
+            MismatchError
+            (1, "2 1 spurious")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -188,31 +188,31 @@ spec_parseTable :: Spec
 spec_parseTable = describe "parseTable" $ do
     it "Failure on no input" $ do
         testTableError
-            parseTable
+            (parseTable id)
             ""
             HeaderError
             (0, "")
 
     it "Failure on incorrect signature" $ do
         testTableError
-            parseTable
+            (parseTable id)
             "incorrect signature"
             HeaderError
             (0, "incorrect signature")
 
     it "Success with empty list of rows" $ do
         testTableSuccess
-            parseTable
+            (parseTable id)
             "tbl-v1.0\nsome arbitrary field"
-            []
+            (makeTable [])
             (2, "")
 
     it "Success case" $ do
         testTableSuccess
-            (fmap toList <$> parseTable)
+            (parseTable toList)
             "tbl-v1.0\nsome arbitrary field\n1 2 3\n2 1 4"
-            [
+            (makeTable [
                 bimap Text.pack Text.pack <$> [("some","1"), ("arbitrary","2"), ("field","3")],
                 bimap Text.pack Text.pack <$> [("some","2"), ("arbitrary","1"), ("field","4")]
-            ]
+            ])
             (4, "")

--- a/tests/Tests/Examples/TableSpec.hs
+++ b/tests/Tests/Examples/TableSpec.hs
@@ -13,177 +13,22 @@ import Tests.Helpers
 -- Module to test.
 import Trisagion.Examples.Table
 
--- Libraries.
-import qualified Data.Text as Text (pack, empty)
-
+-- Auxiliary imports.
 -- Base.
 import Data.Bifunctor (Bifunctor (..))
 import Data.Foldable (Foldable (..))
-import Data.List.NonEmpty (NonEmpty (..))
 
--- Package.
-import Trisagion.Getters.Streamable (InputError (..), MatchError (..) )
+-- Libraries.
+import qualified Data.Text as Text (pack)
 
 
 -- Main module test driver.
 spec :: Spec
 spec = describe "Trisagion.Examples.Table tests" $ do
-    spec_parseHeader
-    spec_parseComment
-    spec_parseFieldOrComment
-    spec_parseRow
-    spec_parseFields
     spec_parseTable
 
 
 -- Tests.
-spec_parseHeader :: Spec
-spec_parseHeader = describe "parseHeader" $ do
-    it "Success case" $ do
-        testTableSuccess
-            parseHeader
-            "tbl-v1.0\nsome more text"
-            (Text.pack "tbl-v1.0")
-            (1, "some more text")
-
-    it "Failure on mismatch" $ do
-        testTableError
-            parseHeader
-            "some arbitrary text\nsome more text"
-            (Right $ MatchError (Text.pack "tbl-v1.0"))
-            (0, "some arbitrary text")
-
-    it "Failure on leading whitespace" $ do
-        testTableError
-            parseHeader
-            "   tbl-v1.0\nsome more text"
-            (Right $ MatchError (Text.pack "tbl-v1.0"))
-            (0, "   tbl-v1.0")
-
-    it "Failure on wrong casing" $ do
-        testTableError
-            parseHeader
-            "TBL-v1.0\nsome more text"
-            (Right $ MatchError (Text.pack "tbl-v1.0"))
-            (0, "TBL-v1.0")
-
-spec_parseComment :: Spec
-spec_parseComment = describe "parseComment" $ do
-    it "Success case" $ do
-        testSuccess
-            parseComment
-            (Text.pack "#some arbitrary text")
-            (Text.pack "some arbitrary text")
-            Text.empty
-
-spec_parseFieldOrComment :: Spec
-spec_parseFieldOrComment = describe "parseFieldOrComment" $ do
-    it "Success on comment" $ do
-        testSuccess
-            parseFieldOrComment
-            (Text.pack "#some arbitrary text")
-            (Left $ Text.pack "some arbitrary text")
-            Text.empty
-
-    it "Success on field" $ do
-        testSuccess
-            parseFieldOrComment
-            (Text.pack "some #arbitrary text")
-            (Right $ Text.pack "some")
-            (Text.pack " #arbitrary text")
-
-    it "Success on whitespace" $ do
-        testSuccess
-            parseFieldOrComment
-            (Text.pack "    ")
-            (Right Text.empty)
-            (Text.pack "    ")
-
-    it "No input" $ do
-        testSuccess
-            parseFieldOrComment
-            Text.empty
-            (Right Text.empty)
-            Text.empty
-
-spec_parseRow :: Spec
-spec_parseRow = describe "parseRow" $ do
-    it "Success in case of only whitespace line" $ do
-        testTableSuccess
-            parseRow
-            "    "
-            []
-            (1, "")
-
-    it "Success in case of comment line" $ do
-        testTableSuccess
-            parseRow
-            "#a commentary"
-            []
-            (1, "")
-
-        testTableSuccess
-            parseRow
-            "     #a commentary"
-            []
-            (1, "")
-
-    it "Success case for fields" $ do
-        testTableSuccess
-            parseRow
-            "    some name"
-            (Text.pack <$> ["some", "name"])
-            (1, "")
-
-        testTableSuccess
-            parseRow
-            "    some name #some commentary"
-            (Text.pack <$> ["some", "name"])
-            (1, "")
-
-spec_parseFields :: Spec
-spec_parseFields = describe "parseFields" $ do
-    it "Success case" $ do
-        testTableSuccess
-            parseFields
-            "some arbitrary text"
-            (Text.pack <$> ("some" :| ["arbitrary", "text"]))
-            (1, "")
-
-    it "Success with leading whitespace" $ do
-        testTableSuccess
-            parseFields
-            " \r\v\t\f   some arbitrary text"
-            (Text.pack <$> ("some" :| ["arbitrary", "text"]))
-            (1, "")
-
-    it "Success with comment character" $ do
-        testTableSuccess
-            parseFields
-            "some #arbitrary omment"
-            (Text.pack <$> ("some" :| []))
-            (1, "")
-
-        testTableSuccess
-            parseFields
-            "some arbi##trary text"
-            (Text.pack <$> ("some" :| ["arbi##trary", "text"]))
-            (1, "")
-
-    it "Failure on no input" $ do
-        testTableError
-            parseFields
-            ""
-            (Left $ InputError 1)
-            (0, "")
-
-    it "Failure on empty list of fields" $ do
-        testTableError
-            parseFields
-            "    #some arbitrary comment"
-            (Right EmptyLineError)
-            (0, "    #some arbitrary comment")
-
 spec_parseTable :: Spec
 spec_parseTable = describe "parseTable" $ do
     it "Failure on no input" $ do

--- a/tests/Tests/Getters/CombinatorsSpec.hs
+++ b/tests/Tests/Getters/CombinatorsSpec.hs
@@ -12,7 +12,8 @@ import Tests.Helpers
 
 -- Module to test.
 import Trisagion.Getters.Combinators
-import qualified Trisagion.Getters.Combinators as Getters (maybe, repeat, sequence, until, zip, zipWith)
+import Trisagion.Getters.Combinators qualified as Getters
+    (either, maybe, repeat, sequence, until, zip, zipWith)
 
 -- Base.
 import Data.Bifunctor (Bifunctor(..))
@@ -34,7 +35,7 @@ spec = describe "Trisagion.Getters.Combinators tests" $ do
     spec_zip
     spec_zipWith
     spec_between
-    spec_eitherOf
+    spec_either
     spec_sequence
     spec_repeat
     spec_many
@@ -246,32 +247,32 @@ spec_between = describe "between" $ do
             ""
             (Left $ InputError 1)
 
-spec_eitherOf :: Spec
-spec_eitherOf = describe "eitherOf" $ do
+spec_either :: Spec
+spec_either = describe "either" $ do
     it "Success of first parser" $ do
         testSuccess
-            (eitherOf one one)
+            (Getters.either one one)
             "0123"
             (Left '0')
             "123"
 
     it "Success on second parser" $ do
         testSuccess
-            (eitherOf (matchElem '1') (first (fmap Left) one))
+            (Getters.either (matchElem '1') (first (fmap Left) one))
             "0123"
             (Right '0')
             "123"
 
     it "Failure of both parsers" $ do
         testError
-            (eitherOf (matchElem '1') (matchElem '2'))
+            (Getters.either (matchElem '1') (matchElem '2'))
             "0123"
             "0123"
             (Right $ MatchError '1')
 
     it "Failure of both parsers but with different errors" $ do
         testError
-            (eitherOf (matchElem '1') (bimap (fmap Left) snd $ Getters.zip one one))
+            (Getters.either (matchElem '1') (bimap (fmap Left) snd $ Getters.zip one one))
             "0"
             "0"
             (Right $ MatchError '1')

--- a/tests/Tests/Helpers.hs
+++ b/tests/Tests/Helpers.hs
@@ -14,6 +14,7 @@ module Tests.Helpers (
 import Test.Hspec
 
 -- Base.
+import Data.Bifunctor (Bifunctor (..))
 import Data.Maybe (listToMaybe)
 import Data.Void (Void)
 
@@ -26,8 +27,7 @@ import Trisagion.Types.Result (Result (..), withResult)
 import Trisagion.Types.ParseError (ParseError (..), getTag, getState)
 import Trisagion.Streams.Streamable (getStream, getOffset)
 import Trisagion.Get (Get, run)
-import Trisagion.Examples.Table (Lines, initLines)
-import Data.Bifunctor (Bifunctor(..))
+import Trisagion.Examples.Table.Parsers (Lines, initLines)
 
  
 {- | Test parser success by testing success equality via @'shouldBe'@. -}

--- a/trisagion.cabal
+++ b/trisagion.cabal
@@ -69,6 +69,7 @@ library
         Trisagion.Getters.Splittable
         Trisagion.Getters.Word8
         Trisagion.Getters.Char
+        Trisagion.Examples.Table.Parsers
         Trisagion.Examples.Table
 
 test-suite trisagion-tests

--- a/trisagion.cabal
+++ b/trisagion.cabal
@@ -90,4 +90,5 @@ test-suite trisagion-tests
         Tests.Getters.SplittableSpec
         Tests.Getters.Word8Spec
         Tests.Getters.CharSpec
+        Tests.Examples.Table.ParsersSpec
         Tests.Examples.TableSpec


### PR DESCRIPTION
Some more changes:

* Rename `eitherOf` to `either`.
* Move table parsers to their own module.
* Improve table parser test coverage.
* Introduce the `Table` type, a newtype wrapper around `Vector a`.
* Refactor `parseRows` and `parseTable`.