### PR TITLE
The `lift` parser.

### DIFF
--- a/src/Trisagion/Parsers/ParseError.hs
+++ b/src/Trisagion/Parsers/ParseError.hs
@@ -13,7 +13,9 @@ module Trisagion.Parsers.ParseError (
 
 -- Imports.
 import Data.Bifunctor (Bifunctor (..))
-import Data.Void (absurd)
+
+-- Libraries.
+import Control.Monad.State (MonadState (..))
 
 -- Package.
 import Trisagion.Types.Result ((:+:))
@@ -26,7 +28,7 @@ import Trisagion.ParserT (ParserT, lift, throw)
 {-# INLINE throwParseError #-}
 throwParseError :: (Monad m, HasOffset m s) => e -> ParserT m s (ParseError e) a
 throwParseError e = do
-    err <- first absurd $ lift (flip makeParseError e)
+    err <- get >>= \ xs -> lift (makeParseError e xs)
     throw err
 
 {- | Capture the offset of the input stream at the entry point in case of an error.
@@ -53,7 +55,7 @@ parser = capture $ do
 {-# INLINE capture #-}
 capture :: (Monad m, HasOffset m s) => ParserT m s (ParseError e) a -> ParserT m s (ParseError e) a
 capture p = do
-        n <- first absurd $ lift offset
+        n  <- get >>= \ xs -> lift (offset xs)
         first (set n) p
     where
         set :: Word -> ParseError e -> ParseError e

--- a/src/Trisagion/Parsers/ParseError.hs
+++ b/src/Trisagion/Parsers/ParseError.hs
@@ -19,7 +19,7 @@ import Control.Monad.State (MonadState (..))
 
 -- Package.
 import Trisagion.Types.Result ((:+:))
-import Trisagion.Types.ParseError (ParseError (..), makeParseError)
+import Trisagion.Types.ParseError (ParseError (..))
 import Trisagion.Typeclasses.HasOffset (HasOffset (..))
 import Trisagion.ParserT (ParserT, lift, throw)
 
@@ -28,7 +28,7 @@ import Trisagion.ParserT (ParserT, lift, throw)
 {-# INLINE throwParseError #-}
 throwParseError :: (Monad m, HasOffset m s) => e -> ParserT m s (ParseError e) a
 throwParseError e = do
-    err <- get >>= \ xs -> lift (makeParseError e xs)
+    err <- get >>= \ xs -> lift ((flip ParseError e) <$> offset xs)
     throw err
 
 {- | Capture the offset of the input stream at the entry point in case of an error.

--- a/src/Trisagion/Types/ParseError.hs
+++ b/src/Trisagion/Types/ParseError.hs
@@ -8,9 +8,6 @@ module Trisagion.Types.ParseError (
     -- * Types.
     ParseError (..),
 
-    -- ** Constructor helpers.
-    makeParseError,
-
     -- * Merging errors.
     cozip,
 ) where
@@ -21,7 +18,6 @@ import Data.Kind (Type)
 
 -- Package.
 import Trisagion.Types.Result ((:+:))
-import Trisagion.Typeclasses.HasOffset (HasOffset (..))
 
 
 {- | The t'ParseError' type. -}
@@ -54,17 +50,6 @@ instance Monoid (ParseError e) where
     mempty :: ParseError e
     mempty = Failure
 
-
-{- | Constructor helper for t'ParseError'. -}
-{-# INLINE makeParseError #-}
-makeParseError
-    :: (HasOffset m s, Monad m)
-    => e                                -- ^ Error tag.
-    -> s                                -- ^ Input stream.
-    -> m (ParseError e)
-makeParseError e xs = do
-    n <- offset xs
-    pure (ParseError n e)
 
 {- | Dual of 'zip' for 'Either'. -}
 {-# INLINE cozip #-}

--- a/src/Trisagion/Types/ParseError.hs
+++ b/src/Trisagion/Types/ParseError.hs
@@ -59,10 +59,10 @@ instance Monoid (ParseError e) where
 {-# INLINE makeParseError #-}
 makeParseError
     :: (HasOffset m s, Monad m)
-    => s                                -- ^ Input stream.
-    -> e                                -- ^ Error tag.
+    => e                                -- ^ Error tag.
+    -> s                                -- ^ Input stream.
     -> m (ParseError e)
-makeParseError xs e = do
+makeParseError e xs = do
     n <- offset xs
     pure (ParseError n e)
 

--- a/src/Trisagion/Types/Result.hs
+++ b/src/Trisagion/Types/Result.hs
@@ -11,7 +11,11 @@ module Trisagion.Types.Result (
     -- * Types.
     Result (..),
 
-    -- * Isomorphisms.
+    -- ** Constructor helpers.
+    errorM,
+    successM,
+
+    -- ** Isomorphisms.
     toEither,
 ) where
 
@@ -40,6 +44,17 @@ instance Bifunctor (Result s) where
     bimap :: (d -> e) -> (a -> b) -> Result s d a -> Result s e b
     bimap f _ (Error e)      = Error (f e)
     bimap _ g (Success x xs) = Success (g x) xs
+
+
+{- | Constructor helper for 'Result'. -}
+{-# INLINE errorM #-}
+errorM :: Applicative m => e -> m (Result s e a)
+errorM = pure . Error
+
+{- | Constructor helper for 'Result'. -}
+{-# INLINE successM #-}
+successM :: Applicative m => a -> s -> m (Result s e a)
+successM x = pure . Success x
 
 
 {- | The isomorphism @'Result' s e a -> 'Either' e (a, s)@. -}

--- a/src/Trisagion/Types/Result.hs
+++ b/src/Trisagion/Types/Result.hs
@@ -11,10 +11,6 @@ module Trisagion.Types.Result (
     -- * Types.
     Result (..),
 
-    -- ** Constructor helpers.
-    errorM,
-    successM,
-
     -- ** Isomorphisms.
     toEither,
 ) where
@@ -44,17 +40,6 @@ instance Bifunctor (Result s) where
     bimap :: (d -> e) -> (a -> b) -> Result s d a -> Result s e b
     bimap f _ (Error e)      = Error (f e)
     bimap _ g (Success x xs) = Success (g x) xs
-
-
-{- | Constructor helper for 'Result'. -}
-{-# INLINE errorM #-}
-errorM :: Applicative m => e -> m (Result s e a)
-errorM = pure . Error
-
-{- | Constructor helper for 'Result'. -}
-{-# INLINE successM #-}
-successM :: Applicative m => a -> s -> m (Result s e a)
-successM x = pure . Success x
 
 
 {- | The isomorphism @'Result' s e a -> 'Either' e (a, s)@. -}


### PR DESCRIPTION
No `MonadTrans` instance because of the order of type parameters. It is either `MonadTrans` or `Bifunctor` and the latter is more useful. 